### PR TITLE
use git for ethportal-api crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1440,8 +1440,8 @@ dependencies = [
  "sea-orm",
  "sea-query",
  "tokio",
- "trin-types",
- "trin-utils",
+ "trin-types 0.1.1-alpha.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "trin-utils 0.1.1-alpha.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -1578,7 +1578,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "219675dc3593f2b99d5cc22d8bbaf956059a66b7eb69444d8502e2b9f5199814"
 dependencies = [
  "hashbrown 0.3.1",
- "keccak-hash 0.8.0",
+ "keccak-hash",
  "log",
  "parking_lot 0.8.0",
  "rlp 0.3.0",
@@ -1697,29 +1697,17 @@ checksum = "0198b9d0078e0f30dedc7acbb21c974e838fc8fae3ee170128658a98cb2c1c04"
 
 [[package]]
 name = "ethportal-api"
-version = "0.1.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0d9b657a02a5bc595f54df26888c52e8e22d13c0b4466427b0afd4e1951e7080"
+version = "0.2.0"
+source = "git+https://github.com/ethereum/trin#6c7f8017fceb8788cb57b143b85cfc3282b8b333"
 dependencies = [
- "bytes",
- "enr 0.7.0",
- "eth2_ssz",
- "eth2_ssz_derive",
+ "discv5 0.2.2",
  "eth2_ssz_types",
- "eth_trie",
  "ethereum-types 0.12.1",
- "ethnum",
- "hex",
- "hex-literal",
  "jsonrpsee",
- "keccak-hash 0.10.0",
- "rand 0.8.5",
- "rlp 0.5.2",
- "rlp-derive",
  "serde",
- "serde-hex",
  "serde_json",
- "sha2 0.10.6",
+ "trin-types 0.1.1-alpha.1 (git+https://github.com/ethereum/trin)",
+ "trin-utils 0.1.1-alpha.1 (git+https://github.com/ethereum/trin)",
 ]
 
 [[package]]
@@ -2061,8 +2049,8 @@ dependencies = [
  "serde_json",
  "tokio",
  "tracing",
- "trin-types",
- "trin-utils",
+ "trin-types 0.1.1-alpha.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "trin-utils 0.1.1-alpha.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "url",
  "web3",
 ]
@@ -2083,7 +2071,7 @@ dependencies = [
  "sea-orm",
  "tokio",
  "tracing",
- "trin-types",
+ "trin-types 0.1.1-alpha.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "url",
 ]
 
@@ -2106,7 +2094,7 @@ dependencies = [
  "sha2 0.10.6",
  "thiserror",
  "tracing",
- "trin-utils",
+ "trin-utils 0.1.1-alpha.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "url",
 ]
 
@@ -2126,7 +2114,7 @@ dependencies = [
  "sea-orm",
  "tokio",
  "tracing",
- "trin-utils",
+ "trin-utils 0.1.1-alpha.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "url",
  "web3",
 ]
@@ -2151,8 +2139,8 @@ dependencies = [
  "tokio",
  "tower-http",
  "tracing",
- "trin-types",
- "trin-utils",
+ "trin-types 0.1.1-alpha.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "trin-utils 0.1.1-alpha.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -2386,12 +2374,6 @@ name = "hex"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
-
-[[package]]
-name = "hex-literal"
-version = "0.3.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ebdb29d2ea9ed0083cd8cece49bbd968021bd99b0849edb4a9a7ee0fdf6a4e0"
 
 [[package]]
 name = "hkdf"
@@ -2931,16 +2913,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ce2bd4c29270e724d3eaadf7bdc8700af4221fc0ed771b855eadcd1b98d52851"
 dependencies = [
  "primitive-types 0.10.1",
- "tiny-keccak 2.0.2",
-]
-
-[[package]]
-name = "keccak-hash"
-version = "0.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4b286e6b663fb926e1eeb68528e69cb70ed46c6d65871a21b2215ae8154c6d3c"
-dependencies = [
- "primitive-types 0.12.1",
  "tiny-keccak 2.0.2",
 ]
 
@@ -5402,7 +5374,7 @@ dependencies = [
  "eth_trie",
  "ethereum-types 0.12.1",
  "ethnum",
- "keccak-hash 0.8.0",
+ "keccak-hash",
  "lazy_static",
  "quickcheck",
  "rand 0.8.5",
@@ -5421,7 +5393,48 @@ dependencies = [
  "tokio",
  "tree_hash",
  "tree_hash_derive",
- "trin-utils",
+ "trin-utils 0.1.1-alpha.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "ureq",
+ "url",
+ "validator",
+]
+
+[[package]]
+name = "trin-types"
+version = "0.1.1-alpha.1"
+source = "git+https://github.com/ethereum/trin#6c7f8017fceb8788cb57b143b85cfc3282b8b333"
+dependencies = [
+ "anyhow",
+ "base64 0.13.1",
+ "bytes",
+ "clap 2.34.0",
+ "discv5 0.2.2",
+ "eth2_ssz",
+ "eth2_ssz_derive",
+ "eth2_ssz_types",
+ "eth_trie",
+ "ethereum-types 0.12.1",
+ "ethnum",
+ "keccak-hash",
+ "lazy_static",
+ "quickcheck",
+ "rand 0.8.5",
+ "rlp 0.5.2",
+ "rlp-derive",
+ "serde",
+ "serde-hex",
+ "serde_json",
+ "serde_yaml",
+ "sha2 0.10.6",
+ "sha3 0.9.1",
+ "snap",
+ "stremio-serde-hex",
+ "structopt",
+ "thiserror",
+ "tokio",
+ "tree_hash",
+ "tree_hash_derive",
+ "trin-utils 0.1.1-alpha.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "ureq",
  "url",
  "validator",
@@ -5432,6 +5445,20 @@ name = "trin-utils"
 version = "0.1.1-alpha.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "69c4d5e151a7bc9c69bb706c5b46cd39c8c12a8e7be877d38b5c3830ff87e8e1"
+dependencies = [
+ "ansi_term",
+ "atty",
+ "hex",
+ "rand 0.8.5",
+ "thiserror",
+ "tracing",
+ "tracing-subscriber",
+]
+
+[[package]]
+name = "trin-utils"
+version = "0.1.1-alpha.1"
+source = "git+https://github.com/ethereum/trin#6c7f8017fceb8788cb57b143b85cfc3282b8b333"
 dependencies = [
  "ansi_term",
  "atty",

--- a/entity/Cargo.toml
+++ b/entity/Cargo.toml
@@ -14,7 +14,7 @@ chrono = "0.4.22"
 clap = { version = "4.0.24", features = ["derive"] }
 enr = "0.8.1"
 ethereum-types = "0.14.0"
-ethportal-api = "0.1.6"
+ethportal-api = { git = "https://github.com/ethereum/trin" }
 glados-core = { path = "../glados-core" }
 migration = { path = "../migration" }
 sea-orm = { version = "0.11.3", features = ["sqlx-postgres", "sqlx-sqlite", "macros", "runtime-tokio-native-tls"] }

--- a/entity/src/content.rs
+++ b/entity/src/content.rs
@@ -2,7 +2,7 @@
 use anyhow::Result;
 use chrono::{DateTime, FixedOffset, Utc};
 use ethereum_types::H256;
-use ethportal_api::types::content_key::OverlayContentKey;
+use ethportal_api::OverlayContentKey;
 use sea_orm::{entity::prelude::*, ActiveValue::NotSet, Set};
 use trin_utils::bytes::{hex_encode, hex_encode_compact};
 

--- a/entity/src/content_audit.rs
+++ b/entity/src/content_audit.rs
@@ -2,7 +2,7 @@
 use anyhow::{bail, Result};
 use chrono::{DateTime, FixedOffset};
 use clap::ValueEnum;
-use ethportal_api::types::content_key::OverlayContentKey;
+use ethportal_api::OverlayContentKey;
 use sea_orm::{entity::prelude::*, ActiveValue::NotSet, Set};
 
 use crate::content;

--- a/entity/src/test.rs
+++ b/entity/src/test.rs
@@ -4,7 +4,7 @@ use std::str::FromStr;
 #[cfg(test)]
 use chrono::prelude::*;
 use ethereum_types::{H256, U256};
-use ethportal_api::types::content_key::{BlockHeaderKey, HistoryContentKey, OverlayContentKey};
+use ethportal_api::{BlockHeaderKey, HistoryContentKey, OverlayContentKey};
 use sea_orm::entity::prelude::*;
 use sea_orm::{
     ActiveModelTrait, ColumnTrait, Database, DbConn, DbErr, EntityTrait, NotSet, PaginatorTrait,

--- a/glados-audit/Cargo.toml
+++ b/glados-audit/Cargo.toml
@@ -15,7 +15,7 @@ clap = { version = "4.0.24", features = ["derive"] }
 entity = { path = "../entity" }
 env_logger = "0.9.3"
 ethereum-types = "0.14.0"
-ethportal-api = "0.1.6"
+ethportal-api = { git = "https://github.com/ethereum/trin" }
 glados-core = { path = "../glados-core" }
 migration = { path = "../migration" }
 rand = "0.8.5"

--- a/glados-audit/src/lib.rs
+++ b/glados-audit/src/lib.rs
@@ -10,7 +10,7 @@ use std::{
 use anyhow::Result;
 use clap::Parser;
 use cli::Args;
-use ethportal_api::types::content_key::{HistoryContentKey, OverlayContentKey};
+use ethportal_api::{HistoryContentKey, OverlayContentKey};
 use sea_orm::DatabaseConnection;
 use tokio::{
     sync::mpsc::{self, Receiver},

--- a/glados-audit/src/selection.rs
+++ b/glados-audit/src/selection.rs
@@ -1,7 +1,7 @@
 use std::collections::HashSet;
 
 use chrono::{DateTime, FixedOffset, TimeZone, Utc};
-use ethportal_api::types::content_key::HistoryContentKey;
+use ethportal_api::HistoryContentKey;
 use rand::{thread_rng, Rng};
 use sea_orm::{
     ColumnTrait, DatabaseConnection, EntityTrait, PaginatorTrait, QueryFilter, QueryOrder,
@@ -277,7 +277,7 @@ mod tests {
         content_audit::{self, AuditResult},
         node,
     };
-    use ethportal_api::types::content_key::{BlockHeaderKey, HistoryContentKey, OverlayContentKey};
+    use ethportal_api::{BlockHeaderKey, HistoryContentKey, OverlayContentKey};
     use migration::{DbErr, Migrator, MigratorTrait};
     use sea_orm::{
         ActiveModelTrait, ActiveValue::NotSet, ColumnTrait, Database, DbConn, EntityTrait,

--- a/glados-audit/src/validation.rs
+++ b/glados-audit/src/validation.rs
@@ -1,4 +1,4 @@
-use ethportal_api::types::content_key::{BlockHeaderKey, HistoryContentKey, OverlayContentKey};
+use ethportal_api::{BlockHeaderKey, HistoryContentKey, OverlayContentKey};
 use tracing::warn;
 use trin_types::content_value::{ContentValue, HistoryContentValue};
 use trin_utils::bytes::hex_encode;

--- a/glados-cartographer/Cargo.toml
+++ b/glados-cartographer/Cargo.toml
@@ -12,7 +12,7 @@ glados-core = { path = "../glados-core" }
 migration = { path = "../migration" }
 entity = { path = "../entity" }
 env_logger = "0.10.0"
-ethportal-api = "0.1.6"
+ethportal-api = { git = "https://github.com/ethereum/trin" }
 sea-orm = "0.11.3"
 tokio = { version = "1.27.0", features = ["signal"] }
 tracing = "0.1.37"

--- a/glados-cartographer/src/lib.rs
+++ b/glados-cartographer/src/lib.rs
@@ -3,9 +3,7 @@ use clap::Parser;
 use cli::Args;
 use ethereum_types::H256;
 use ethportal_api::HistoryNetworkApiClient;
-use ethportal_api::{
-    jsonrpsee::http_client::HttpClientBuilder, types::discv5::NodeId as EthPortalNodeId,
-};
+use ethportal_api::{jsonrpsee::http_client::HttpClientBuilder, NodeId as EthPortalNodeId};
 use sea_orm::DatabaseConnection;
 use tokio::time::{self, Duration};
 use tracing::{debug, info};

--- a/glados-core/Cargo.toml
+++ b/glados-core/Cargo.toml
@@ -19,7 +19,7 @@ sha2 = "0.10.6"
 thiserror = "1.0.37"
 env_logger = "0.9.3"
 tracing = "0.1.37"
-ethportal-api = "0.1.6"
+ethportal-api = { git = "https://github.com/ethereum/trin" }
 trin-utils = "0.1.1-alpha.1"
 url = "2.3.1"
 jsonrpsee = { version = "0.16.2", features = ["client"] }

--- a/glados-core/src/jsonrpc.rs
+++ b/glados-core/src/jsonrpc.rs
@@ -5,7 +5,6 @@ use std::path::PathBuf;
 use std::str::FromStr;
 
 use ethereum_types::{H256, U256};
-use ethportal_api::types::content_key::OverlayContentKey;
 use jsonrpc::Request;
 use jsonrpsee::{
     core::{client::ClientT, params::ArrayParams},
@@ -18,16 +17,15 @@ use serde_json::{
     value::{to_raw_value, RawValue},
     Value,
 };
-use trin_utils::bytes::hex_encode;
-
 use thiserror::Error;
 use tracing::error;
+use trin_utils::bytes::hex_encode;
 use trin_utils::bytes::{hex_decode, ByteUtilsError};
 #[cfg(windows)]
 use uds_windows::UnixStream;
 use url::Url;
 
-use ethportal_api::types::discv5::Enr;
+use ethportal_api::{Enr, OverlayContentKey};
 
 /// Configuration details for connection to a Portal network node.
 #[derive(Clone, Debug)]

--- a/glados-monitor/Cargo.toml
+++ b/glados-monitor/Cargo.toml
@@ -21,6 +21,6 @@ ethereum-types = "0.14.0"
 env_logger = "0.9.3"
 tracing = "0.1.37"
 trin-utils = "0.1.1-alpha.1"
-ethportal-api = "0.1.6"
+ethportal-api = { git = "https://github.com/ethereum/trin" }
 reqwest = "0.11.6"
 url = "2.2.2"

--- a/glados-monitor/src/lib.rs
+++ b/glados-monitor/src/lib.rs
@@ -2,7 +2,7 @@ use std::path::PathBuf;
 use std::time::Duration;
 
 use anyhow::{Error, Result};
-use ethportal_api::types::content_key::{
+use ethportal_api::{
     BlockBodyKey, BlockHeaderKey, BlockReceiptsKey, EpochAccumulatorKey, HistoryContentKey,
     OverlayContentKey,
 };

--- a/glados-web/Cargo.toml
+++ b/glados-web/Cargo.toml
@@ -18,7 +18,7 @@ enr = "0.8.1"
 entity = { path = "../entity" }
 env_logger = "0.9.3"
 ethereum-types = "0.14.0"
-ethportal-api = "0.1.6"
+ethportal-api = { git = "https://github.com/ethereum/trin" }
 glados-core = { path = "../glados-core" }
 migration = { path = "../migration" }
 sea-orm = "0.11.3"

--- a/glados-web/src/routes.rs
+++ b/glados-web/src/routes.rs
@@ -12,7 +12,7 @@ use entity::{
     content_audit::{self, AuditResult},
     execution_metadata, key_value, node, record,
 };
-use ethportal_api::types::content_key::{HistoryContentKey, OverlayContentKey};
+use ethportal_api::{HistoryContentKey, OverlayContentKey};
 use sea_orm::{
     ColumnTrait, DatabaseConnection, EntityTrait, ModelTrait, PaginatorTrait, QueryFilter,
     QueryOrder, QuerySelect,


### PR DESCRIPTION
## What was wrong

`ethportal-api` was behind that available on `trin`. Keeping up to date requires action on the `trin` side, which has included friction when `trin` publishing is not possible without changes to the `ethportal-api` crate.

## What was changed

Move ethportal-api to point to git instead of crates so that glados can use the latest ethportal-api by running:
```command
cargo update -p ethportal-api
```