### PR TITLE
Remove ip from NodeInfo struct to comply to portal-json-rpc specs

### DIFF
--- a/glados-core/src/jsonrpc.rs
+++ b/glados-core/src/jsonrpc.rs
@@ -139,7 +139,6 @@ pub struct JsonRPCResult {
 pub struct NodeInfo {
     pub enr: String,
     pub nodeId: String,
-    pub ip: String,
 }
 
 #[allow(non_snake_case)]


### PR DESCRIPTION
`discv5_nodeInfo` started to be used in one of the recent commits, however it is not according to the specifications breaking compatibility with Fluffy.

This PR should resolve that. 

The IP field is not being used in the code anyhow, so its easy to remove.