### PR TITLE
Use client info within dashboard

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2100,6 +2100,7 @@ dependencies = [
  "jsonrpsee",
  "jsonrpsee-core",
  "jsonrpsee-types",
+ "rstest",
  "rustc-hex",
  "serde",
  "serde_json",
@@ -2146,6 +2147,7 @@ dependencies = [
  "ethereum-types 0.14.1",
  "ethportal-api",
  "glados-core",
+ "itertools",
  "migration",
  "sea-orm",
  "tokio",
@@ -4064,6 +4066,19 @@ checksum = "e33d7b2abe0c340d8797fe2907d3f20d3b5ea5908683618bfe80df7f621f672a"
 dependencies = [
  "proc-macro2",
  "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
+name = "rstest"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2288c66aeafe3b2ed227c981f364f9968fa952ef0b30e84ada4486e7ee24d00a"
+dependencies = [
+ "cfg-if 1.0.0",
+ "proc-macro2",
+ "quote",
+ "rustc_version 0.4.0",
  "syn 1.0.109",
 ]
 

--- a/entity/src/node.rs
+++ b/entity/src/node.rs
@@ -124,8 +124,6 @@ pub async fn get_or_create(node_id: NodeId, conn: &DatabaseConnection) -> Result
     let raw_node_id = U256::from_big_endian(node_id.raw().as_slice());
     let node_id_high: i64 = (raw_node_id >> 193).as_u64().try_into().unwrap();
 
-    // let client_info = client_info::get_or_create(,&conn)
-
     let node_id_model = ActiveModel {
         id: NotSet,
         node_id: Set(node_id.raw().into()),

--- a/glados-core/Cargo.toml
+++ b/glados-core/Cargo.toml
@@ -26,3 +26,6 @@ jsonrpsee = { version = "0.16.2", features = ["client"] }
 jsonrpsee-types = "0.16.2"
 rustc-hex = "2.1.0"
 jsonrpsee-core = "0.16.2"
+
+[dev-dependencies]
+rstest = "0.11.0"

--- a/glados-web/Cargo.toml
+++ b/glados-web/Cargo.toml
@@ -21,6 +21,7 @@ ethereum-types = "0.14.0"
 ethportal-api = "0.1.6"
 glados-core = { path = "../glados-core" }
 migration = { path = "../migration" }
+itertools = "0.10.5"
 sea-orm = "0.11.3"
 tokio = "1.22.0"
 tower-http = { version = "0.3.5", features = ["fs"] }

--- a/glados-web/src/templates.rs
+++ b/glados-web/src/templates.rs
@@ -4,7 +4,7 @@ use axum::{
     response::{Html, IntoResponse, Response},
 };
 
-use entity::{content, content_audit, key_value, node, record};
+use entity::{client_info, content, content_audit, key_value, node, record};
 
 use crate::routes::Stats;
 
@@ -39,15 +39,17 @@ pub struct EnrDetailTemplate {
     pub key_value_list: Vec<key_value::Model>,
 }
 
+pub type AuditTuple = (content_audit::Model, content::Model, client_info::Model);
+
 #[derive(Template)]
 #[template(path = "content_dashboard.html")]
 pub struct ContentDashboardTemplate {
     pub stats: [Stats; 3],
     pub contentid_list: Vec<content::Model>,
-    pub recent_content: Vec<(content::Model, content_audit::Model)>,
-    pub recent_audits: Vec<(content::Model, content_audit::Model)>,
-    pub recent_audit_successes: Vec<(content::Model, content_audit::Model)>,
-    pub recent_audit_failures: Vec<(content::Model, content_audit::Model)>,
+    pub audits_of_recent_content: Vec<AuditTuple>,
+    pub recent_audits: Vec<AuditTuple>,
+    pub recent_audit_successes: Vec<AuditTuple>,
+    pub recent_audit_failures: Vec<AuditTuple>,
 }
 
 #[derive(Template)]

--- a/glados-web/templates/content_dashboard.html
+++ b/glados-web/templates/content_dashboard.html
@@ -57,10 +57,12 @@
                         <th scope="col">Content ID</th>
                         <th scope="col">Content first available</th>
                         <th scope="col">Audited at</th>
+                        <th scope="col">Client</th>
+
                     </tr>
                 </thead>
                 <tbody>
-                    {% for (content, audit) in recent_content %}
+                    {% for (audit, content, client_info) in audits_of_recent_content %}
                     <tr>
                         <td>{% if audit.trace != "" %}<a href="/audit/id/{{ audit.id }}">{{ audit.id }}</a>{% else %}
                             {{ audit.id }}{% endif %}</td>
@@ -72,6 +74,7 @@
                         <td><a href="/content/id/{{content.id_as_hex()}}/">{{ content.id_as_hex_short() }}</a></td>
                         <td>{{ content.available_at_local_time() }}</td>
                         <td>{{ audit.created_at_local_time() }}</td>
+                        <td>{{ client_info.version_info }}</td>
                     </tr>
                     {% endfor %}
                 </tbody>
@@ -121,10 +124,11 @@
                         <th scope="col">Content ID</th>
                         <th scope="col">Content first available</th>
                         <th scope="col">Audited at</th>
+                        <th scope="col">Client</th>
                     </tr>
                 </thead>
                 <tbody>
-                    {% for (content, audit) in recent_audits %}
+                    {% for (audit, content, client_info) in recent_audits %}
                     <tr>
                         <td>{% if audit.trace != "" %}<a href="/audit/id/{{ audit.id }}">{{ audit.id }}</a>{% else %}
                             {{ audit.id }}{% endif %}</td>
@@ -136,6 +140,7 @@
                         <td><a href="/content/id/{{content.id_as_hex()}}/">{{ content.id_as_hex_short() }}</a></td>
                         <td>{{ content.available_at_local_time() }}</td>
                         <td>{{ audit.created_at_local_time() }}</td>
+                        <td>{{ client_info.version_info }}</td>
                     </tr>
                     {% endfor %}
                 </tbody>
@@ -158,10 +163,11 @@
                         <th scope="col">Content ID</th>
                         <th scope="col">Content first available</th>
                         <th scope="col">Audited at</th>
+                        <th scope="col">Client</th>
                     </tr>
                 </thead>
                 <tbody>
-                    {% for (content, audit) in recent_audit_successes %}
+                    {% for (audit, content, client_info) in recent_audit_successes %}
                     <tr>
                         <td>{% if audit.trace != "" %}<a href="/audit/id/{{ audit.id }}">{{ audit.id }}</a>{% else %}
                             {{ audit.id }}{% endif %}</td>
@@ -173,6 +179,7 @@
                         <td><a href="/content/id/{{content.id_as_hex()}}/">{{ content.id_as_hex_short() }}</a></td>
                         <td>{{ content.available_at_local_time() }}</td>
                         <td>{{ audit.created_at_local_time() }}</td>
+                        <td>{{ client_info.version_info }}</td>
                     </tr>
                     {% endfor %}
                 </tbody>
@@ -195,10 +202,11 @@
                         <th scope="col">Content ID</th>
                         <th scope="col">Content first available</th>
                         <th scope="col">Audited at</th>
+                        <th scope="col">Client</th>
                     </tr>
                 </thead>
                 <tbody>
-                    {% for (content, audit) in recent_audit_failures %}
+                    {% for (audit, content, client_info) in recent_audit_failures %}
                     <tr>
                         <td>{% if audit.trace != "" %}<a href="/audit/id/{{ audit.id }}">{{ audit.id }}</a>{% else %}
                             {{ audit.id }}{% endif %}</td>
@@ -210,6 +218,7 @@
                         <td><a href="/content/id/{{content.id_as_hex()}}/">{{ content.id_as_hex_short() }}</a></td>
                         <td>{{ content.available_at_local_time() }}</td>
                         <td>{{ audit.created_at_local_time() }}</td>
+                        <td>{{ client_info.version_info }}</td>
                     </tr>
                     {% endfor %}
                 </tbody>


### PR DESCRIPTION
Fixes #124 

- [x] add client info for each audit to dashboard
- [x] refactor `content_dashboard` route function to use [seaorm's DataLoader api](https://www.sea-ql.org/SeaORM/docs/relation/data-loader/), which is 1. more ergonomic for loading related data and 2. is more efficient as it doesn't load duplicate data.  Though I wonder if we should just be doing a big join and load it all in one query rather than 2 or 3 separate calls. 