### PR TITLE
Add specific single key audit

### DIFF
--- a/entity/src/content_audit.rs
+++ b/entity/src/content_audit.rs
@@ -34,6 +34,8 @@ pub enum SelectionStrategy {
     /// 1. Not yet audited.
     /// 2. Sorted by date entered into glados database (oldest first).
     SelectOldestUnaudited = 3,
+    /// Perform a single audit for a previously audited content key.
+    SpecificContentKey = 4,
 }
 
 impl AuditResult {
@@ -156,6 +158,7 @@ impl SelectionStrategy {
             SelectionStrategy::Random => "Random".to_string(),
             SelectionStrategy::Failed => "Failed".to_string(),
             SelectionStrategy::SelectOldestUnaudited => "Select Oldest Unaudited".to_string(),
+            SelectionStrategy::SpecificContentKey => "Specific Content Key".to_string(),
         }
     }
 }

--- a/glados-audit/src/cli.rs
+++ b/glados-audit/src/cli.rs
@@ -1,4 +1,4 @@
-use clap::{ArgAction, Parser, ValueEnum};
+use clap::{ArgAction, Parser, Subcommand, ValueEnum};
 use entity::content_audit::SelectionStrategy;
 
 const DEFAULT_DB_URL: &str = "sqlite::memory:";
@@ -42,6 +42,18 @@ pub struct Args {
     pub random_strategy_weight: u8,
     #[arg(short, long, action(ArgAction::Append))]
     pub portal_client: Vec<String>,
+    #[command(subcommand)]
+    pub subcommand: Option<Command>,
+}
+
+#[derive(Subcommand, Debug, Eq, PartialEq, Clone)]
+pub enum Command {
+    /// Run a single audit for a specific, previously audited content key.
+    Audit {
+        content_key: String,
+        portal_client: String,
+        database_url: String,
+    },
 }
 
 impl Default for Args {
@@ -55,6 +67,7 @@ impl Default for Args {
             random_strategy_weight: 1,
             strategy: None,
             portal_client: vec!["ipc:////tmp/trin-jsonrpc.ipc".to_owned()],
+            subcommand: None,
         }
     }
 }

--- a/glados-audit/src/main.rs
+++ b/glados-audit/src/main.rs
@@ -1,15 +1,17 @@
 use anyhow::Result;
+use clap::Parser;
 use sea_orm::Database;
 use tracing::{debug, info};
 
-use glados_audit::{run_glados_audit, AuditConfig};
+use glados_audit::cli::{Args, Command};
+use glados_audit::{run_glados_audit, run_glados_command, AuditConfig};
 use migration::{Migrator, MigratorTrait};
 
 #[tokio::main]
 async fn main() -> Result<()> {
     // Setup logging
     env_logger::init();
-
+    let args = Args::parse();
     info!("Starting glados-audit");
 
     //
@@ -17,25 +19,49 @@ async fn main() -> Result<()> {
     //
     debug!("Parsing CLI arguments");
 
-    let config = AuditConfig::from_args().await?;
+    match args.subcommand {
+        Some(command) => run_command(command).await?,
+        None => run_audit(args).await?,
+    }
+    Ok(())
+}
 
+async fn run_command(command: Command) -> Result<()> {
     //
     // Database Connection
     //
+    let database_url = match &command {
+        Command::Audit { database_url, .. } => database_url,
+    };
+    debug!(database_url = database_url, "Connecting to database");
+
+    let conn = Database::connect(database_url).await?;
+    info!(
+        database_url = database_url,
+        "database connection established"
+    );
+
+    Migrator::up(&conn, None).await?;
+    run_glados_command(conn, command).await
+}
+
+async fn run_audit(args: Args) -> Result<()> {
+    //
+    // Database Connection
+    //
+    let config = AuditConfig::from_args(args).await?;
     debug!(
         database_url = &config.database_url,
         "Connecting to database"
     );
 
     let conn = Database::connect(&config.database_url).await?;
-
     info!(
         database_url = &config.database_url,
         "database connection established"
     );
 
     Migrator::up(&conn, None).await?;
-
     run_glados_audit(conn, config).await;
     Ok(())
 }

--- a/glados-audit/src/selection.rs
+++ b/glados-audit/src/selection.rs
@@ -32,6 +32,9 @@ pub async fn start_audit_selection_task(
         SelectionStrategy::SelectOldestUnaudited => {
             select_oldest_unaudited_content_for_audit(tx, conn).await
         }
+        SelectionStrategy::SpecificContentKey => {
+            error!("SpecificContentKey is not a valid audit strategy")
+        }
     }
 }
 
@@ -464,7 +467,6 @@ mod tests {
             // Check that strategy only yields expected keys.
             assert!(expected_key_ids.contains(&key_model.id));
             checked_ids.insert(key_model.id);
-            println!("ids checked {}", checked_ids.len());
             if checked_ids.len() == CHANNEL_SIZE {
                 break;
             }

--- a/glados-monitor/src/lib.rs
+++ b/glados-monitor/src/lib.rs
@@ -141,7 +141,7 @@ async fn store_block_keys(block_number: i32, block_hash: &[u8; 32], conn: &Datab
     store_content_key(&receipts, "block_receipts", block_number, conn).await;
 }
 
-/// Accepts a ContentKey from the Historyand attempts to store it.
+/// Accepts a ContentKey from the History and attempts to store it.
 ///
 /// Errors are logged.
 async fn store_content_key<T: OverlayContentKey>(


### PR DESCRIPTION
Add a subcommand to glados that executes a single one-off audit for previously audited content keys. This command is only functional for on-disk databases, passed in via a cli arg, and will not be effective on in-memory dbs. 

- Skipped support for all valid content keys (not just previously audited ones) to avoid complexity involved w/ looking up the block number via `web3` & inserting it into db. I figured if the use case is important, it can be added later
- Spent some time playing around with various configurations of the cli parser / subcommand structure. In the end this was the simplest design I could get to work.
