### PR TITLE
Add ``.idea`` and ``venv`` to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,7 @@
 /target
+
+# where jetbrains IDE's store stuff
+.idea
+
+# most popular python virtual enviroment folder name
+venv


### PR DESCRIPTION
### What was wrong?
Jetbrains is a popular IDE for Rust not having ``.idea`` in gitignore creates extra time spent on avoiding commiting its files

Operating systems like Ubuntu 23.04 don't allow global pip installs by default making users instead use isolated virtual enviroments. Creating a ``venv`` adds 20k files and depending what software people use to commit switching between branches can spam the changed files view in visual git clients like GitHub Desktop forcing the developer to either manually add in command line, add the ignore locally every time they switch branches, or create a new venv each time.

### How was it fixed?
Adding ``.idea`` and ``venv`` to .gitignore