### PR TITLE
Remove unused constants

### DIFF
--- a/glados-web/src/routes.rs
+++ b/glados-web/src/routes.rs
@@ -101,7 +101,6 @@ pub async fn node_detail(
     Path(node_id_hex): Path<String>,
     Extension(state): Extension<Arc<State>>,
 ) -> Result<HtmlTemplate<NodeDetailTemplate>, StatusCode> {
-    const KEY_COUNT: u64 = 50;
     let node_id = hex_decode(&node_id_hex).map_err(|e| {
         error!(node_id=node_id_hex, err=?e, "Could not decode proved node_id");
         StatusCode::INTERNAL_SERVER_ERROR
@@ -159,7 +158,6 @@ pub async fn enr_detail(
     Path((node_id_hex, enr_seq)): Path<(String, u64)>,
     Extension(state): Extension<Arc<State>>,
 ) -> Result<HtmlTemplate<EnrDetailTemplate>, StatusCode> {
-    const KEY_COUNT: u64 = 50;
     let node_id = hex_decode(&node_id_hex).map_err(|e| {
         error!(node_id=node_id_hex, err=?e, "Could not decode proved node_id");
         StatusCode::INTERNAL_SERVER_ERROR


### PR DESCRIPTION
### What was wrong?
```bash
error: constant `KEY_COUNT` is never used
   --> glados-web/src/routes.rs:104:11
    |
104 |     const KEY_COUNT: u64 = 50;
    |           ^^^^^^^^^
    |
    = note: `-D dead-code` implied by `-D warnings`

error: constant `KEY_COUNT` is never used
   --> glados-web/src/routes.rs:162:11
    |
162 |     const KEY_COUNT: u64 = 50;
    |           ^^^^^^^^^

error: could not compile `glados-web` due to 2 previous errors
```
when I run the clippy command found in the the circle CI config I get these errors for never used constants. I am not sure why CI isn't picking it up, but it is on my Ubuntu 23.04 install
### How was it fixed?
by removing the unused constants