### PR TITLE
Get content query trace from trin nodes

### DIFF
--- a/glados-core/src/jsonrpc.rs
+++ b/glados-core/src/jsonrpc.rs
@@ -238,6 +238,10 @@ impl PortalClient {
             enr,
         })
     }
+
+    pub fn is_trin(self) -> bool {
+        self.client_info.contains("trin")
+    }
 }
 
 impl PortalApi {


### PR DESCRIPTION
Conditionally call `portal_historyTraceRecursiveFindContent` if auditing using trin node