### PR TITLE
`ethportal_api` Integration

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2085,6 +2085,7 @@ dependencies = [
  "jsonrpsee",
  "jsonrpsee-core",
  "jsonrpsee-types",
+ "reth-ipc",
  "rstest",
  "rustc-hex",
  "serde",
@@ -2473,26 +2474,11 @@ dependencies = [
  "http",
  "hyper",
  "log",
- "rustls 0.20.8",
+ "rustls",
  "rustls-native-certs",
  "tokio",
- "tokio-rustls 0.23.4",
- "webpki-roots 0.22.6",
-]
-
-[[package]]
-name = "hyper-rustls"
-version = "0.24.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0646026eb1b3eea4cd9ba47912ea5ce9cc07713d105b1a14698f4e6433d348b7"
-dependencies = [
- "http",
- "hyper",
- "log",
- "rustls 0.21.1",
- "rustls-native-certs",
- "tokio",
- "tokio-rustls 0.24.0",
+ "tokio-rustls",
+ "webpki-roots",
 ]
 
 [[package]]
@@ -2725,30 +2711,15 @@ version = "0.16.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7d291e3a5818a2384645fd9756362e6d89cf0541b0b916fa7702ea4a9833608e"
 dependencies = [
- "jsonrpsee-client-transport 0.16.2",
- "jsonrpsee-core 0.16.2",
- "jsonrpsee-http-client 0.16.2",
+ "jsonrpsee-client-transport",
+ "jsonrpsee-core",
+ "jsonrpsee-http-client",
  "jsonrpsee-proc-macros",
- "jsonrpsee-server 0.16.2",
- "jsonrpsee-types 0.16.2",
- "jsonrpsee-wasm-client 0.16.2",
- "jsonrpsee-ws-client 0.16.2",
+ "jsonrpsee-server",
+ "jsonrpsee-types",
+ "jsonrpsee-wasm-client",
+ "jsonrpsee-ws-client",
  "tracing",
-]
-
-[[package]]
-name = "jsonrpsee"
-version = "0.18.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1822d18e4384a5e79d94dc9e4d1239cfa9fad24e55b44d2efeff5b394c9fece4"
-dependencies = [
- "jsonrpsee-client-transport 0.18.2",
- "jsonrpsee-core 0.18.2",
- "jsonrpsee-http-client 0.18.2",
- "jsonrpsee-server 0.18.2",
- "jsonrpsee-types 0.18.2",
- "jsonrpsee-wasm-client 0.18.2",
- "jsonrpsee-ws-client 0.18.2",
 ]
 
 [[package]]
@@ -2763,39 +2734,17 @@ dependencies = [
  "futures-util",
  "gloo-net",
  "http",
- "jsonrpsee-core 0.16.2",
- "jsonrpsee-types 0.16.2",
+ "jsonrpsee-core",
+ "jsonrpsee-types",
  "pin-project",
  "rustls-native-certs",
  "soketto",
  "thiserror",
  "tokio",
- "tokio-rustls 0.23.4",
+ "tokio-rustls",
  "tokio-util 0.7.7",
  "tracing",
- "webpki-roots 0.22.6",
-]
-
-[[package]]
-name = "jsonrpsee-client-transport"
-version = "0.18.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "11aa5766d5c430b89cb26a99b88f3245eb91534be8126102cea9e45ee3891b22"
-dependencies = [
- "futures-channel",
- "futures-util",
- "gloo-net",
- "http",
- "jsonrpsee-core 0.18.2",
- "pin-project",
- "rustls-native-certs",
- "soketto",
- "thiserror",
- "tokio",
- "tokio-rustls 0.24.0",
- "tokio-util 0.7.7",
- "tracing",
- "webpki-roots 0.23.0",
+ "webpki-roots",
 ]
 
 [[package]]
@@ -2814,7 +2763,7 @@ dependencies = [
  "futures-util",
  "globset",
  "hyper",
- "jsonrpsee-types 0.16.2",
+ "jsonrpsee-types",
  "parking_lot 0.12.1",
  "rand 0.8.5",
  "rustc-hash",
@@ -2823,34 +2772,6 @@ dependencies = [
  "soketto",
  "thiserror",
  "tokio",
- "tracing",
- "wasm-bindgen-futures",
-]
-
-[[package]]
-name = "jsonrpsee-core"
-version = "0.18.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "64c6832a55f662b5a6ecc844db24b8b9c387453f923de863062c60ce33d62b81"
-dependencies = [
- "anyhow",
- "async-lock",
- "async-trait",
- "beef",
- "futures-timer",
- "futures-util",
- "globset",
- "hyper",
- "jsonrpsee-types 0.18.2",
- "parking_lot 0.12.1",
- "rand 0.8.5",
- "rustc-hash",
- "serde",
- "serde_json",
- "soketto",
- "thiserror",
- "tokio",
- "tokio-stream",
  "tracing",
  "wasm-bindgen-futures",
 ]
@@ -2863,33 +2784,14 @@ checksum = "cc345b0a43c6bc49b947ebeb936e886a419ee3d894421790c969cc56040542ad"
 dependencies = [
  "async-trait",
  "hyper",
- "hyper-rustls 0.23.2",
- "jsonrpsee-core 0.16.2",
- "jsonrpsee-types 0.16.2",
+ "hyper-rustls",
+ "jsonrpsee-core",
+ "jsonrpsee-types",
  "rustc-hash",
  "serde",
  "serde_json",
  "thiserror",
  "tokio",
- "tracing",
-]
-
-[[package]]
-name = "jsonrpsee-http-client"
-version = "0.18.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1705c65069729e3dccff6fd91ee431d5d31cabcf00ce68a62a2c6435ac713af9"
-dependencies = [
- "async-trait",
- "hyper",
- "hyper-rustls 0.24.0",
- "jsonrpsee-core 0.18.2",
- "jsonrpsee-types 0.18.2",
- "serde",
- "serde_json",
- "thiserror",
- "tokio",
- "tower",
  "tracing",
 ]
 
@@ -2916,28 +2818,8 @@ dependencies = [
  "futures-util",
  "http",
  "hyper",
- "jsonrpsee-core 0.16.2",
- "jsonrpsee-types 0.16.2",
- "serde",
- "serde_json",
- "soketto",
- "tokio",
- "tokio-stream",
- "tokio-util 0.7.7",
- "tower",
- "tracing",
-]
-
-[[package]]
-name = "jsonrpsee-server"
-version = "0.18.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4f06661d1a6b6e5b85469dc9c29acfbb9b3bb613797a6fd10a3ebb8a70754057"
-dependencies = [
- "futures-util",
- "hyper",
- "jsonrpsee-core 0.18.2",
- "jsonrpsee-types 0.18.2",
+ "jsonrpsee-core",
+ "jsonrpsee-types",
  "serde",
  "serde_json",
  "soketto",
@@ -2963,39 +2845,14 @@ dependencies = [
 ]
 
 [[package]]
-name = "jsonrpsee-types"
-version = "0.18.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e5bf6c75ce2a4217421154adfc65a24d2b46e77286e59bba5d9fa6544ccc8f4"
-dependencies = [
- "anyhow",
- "beef",
- "serde",
- "serde_json",
- "thiserror",
- "tracing",
-]
-
-[[package]]
 name = "jsonrpsee-wasm-client"
 version = "0.16.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a77310456f43c6c89bcba1f6b2fc2a28300da7c341f320f5128f8c83cc63232d"
 dependencies = [
- "jsonrpsee-client-transport 0.16.2",
- "jsonrpsee-core 0.16.2",
- "jsonrpsee-types 0.16.2",
-]
-
-[[package]]
-name = "jsonrpsee-wasm-client"
-version = "0.18.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34e6ea7c6d862e60f8baebd946c037b70c6808a4e4e31e792a4029184e3ce13a"
-dependencies = [
- "jsonrpsee-client-transport 0.18.2",
- "jsonrpsee-core 0.18.2",
- "jsonrpsee-types 0.18.2",
+ "jsonrpsee-client-transport",
+ "jsonrpsee-core",
+ "jsonrpsee-types",
 ]
 
 [[package]]
@@ -3005,21 +2862,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b83daeecfc6517cfe210df24e570fb06213533dfb990318fae781f4c7119dd9"
 dependencies = [
  "http",
- "jsonrpsee-client-transport 0.16.2",
- "jsonrpsee-core 0.16.2",
- "jsonrpsee-types 0.16.2",
-]
-
-[[package]]
-name = "jsonrpsee-ws-client"
-version = "0.18.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a64b2589680ba1ad7863f279cd2d5083c1dc0a7c0ea959d22924553050f8ab9f"
-dependencies = [
- "http",
- "jsonrpsee-client-transport 0.18.2",
- "jsonrpsee-core 0.18.2",
- "jsonrpsee-types 0.18.2",
+ "jsonrpsee-client-transport",
+ "jsonrpsee-core",
+ "jsonrpsee-types",
 ]
 
 [[package]]
@@ -4114,18 +3959,17 @@ dependencies = [
 [[package]]
 name = "reth-ipc"
 version = "0.1.0"
-source = "git+https://github.com/paradigmxyz/reth.git#e4cd48aefdd0d52781f03ec0d8840841ba0c818a"
+source = "git+https://github.com/paradigmxyz/reth.git#546e191e8a9f081f83c0a9357497b93d28fc0275"
 dependencies = [
  "async-trait",
  "bytes",
  "futures",
- "jsonrpsee 0.18.2",
+ "jsonrpsee",
  "parity-tokio-ipc",
  "pin-project",
  "serde_json",
  "thiserror",
  "tokio",
- "tokio-stream",
  "tokio-util 0.7.7",
  "tower",
  "tracing",
@@ -4326,18 +4170,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "rustls"
-version = "0.21.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c911ba11bc8433e811ce56fde130ccf32f5127cab0e0194e9c68c5a5b671791e"
-dependencies = [
- "log",
- "ring",
- "rustls-webpki",
- "sct",
-]
-
-[[package]]
 name = "rustls-native-certs"
 version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4356,16 +4188,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d194b56d58803a43635bdc398cd17e383d6f71f9182b9a192c127ca42494a59b"
 dependencies = [
  "base64 0.21.0",
-]
-
-[[package]]
-name = "rustls-webpki"
-version = "0.100.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d6207cd5ed3d8dca7816f8f3725513a34609c0c765bf652b8c3cb4cfd87db46b"
-dependencies = [
- "ring",
- "untrusted",
 ]
 
 [[package]]
@@ -5316,19 +5138,9 @@ version = "0.23.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c43ee83903113e03984cb9e5cebe6c04a5116269e900e3ddba8f068a62adda59"
 dependencies = [
- "rustls 0.20.8",
+ "rustls",
  "tokio",
  "webpki",
-]
-
-[[package]]
-name = "tokio-rustls"
-version = "0.24.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e0d409377ff5b1e3ca6437aa86c1eb7d40c134bfec254e44c830defa92669db5"
-dependencies = [
- "rustls 0.21.1",
- "tokio",
 ]
 
 [[package]]
@@ -5659,12 +5471,12 @@ dependencies = [
  "flate2",
  "log",
  "once_cell",
- "rustls 0.20.8",
+ "rustls",
  "serde",
  "serde_json",
  "url",
  "webpki",
- "webpki-roots 0.22.6",
+ "webpki-roots",
 ]
 
 [[package]]
@@ -5935,15 +5747,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6c71e40d7d2c34a5106301fb632274ca37242cd0c9d3e64dbece371a40a2d87"
 dependencies = [
  "webpki",
-]
-
-[[package]]
-name = "webpki-roots"
-version = "0.23.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aa54963694b65584e170cf5dc46aeb4dcaa5584e652ff5f3952e56d66aff0125"
-dependencies = [
- "rustls-webpki",
 ]
 
 [[package]]

--- a/glados-core/Cargo.toml
+++ b/glados-core/Cargo.toml
@@ -21,7 +21,7 @@ env_logger = "0.9.3"
 tracing = "0.1.37"
 ethportal-api = "0.2.0"
 url = "2.3.1"
-jsonrpsee = { version = "0.18.2", features = ["async-client", "client"] }
+jsonrpsee = { version = "0.16.2", features = ["async-client", "client"] }
 jsonrpsee-types = "0.16.2"
 rustc-hex = "2.1.0"
 jsonrpsee-core = "0.16.2"

--- a/glados-core/src/jsonrpc.rs
+++ b/glados-core/src/jsonrpc.rs
@@ -1,3 +1,4 @@
+use ethportal_api::{Discv5ApiClient, Web3ApiClient};
 #[cfg(unix)]
 use reth_ipc::client::{IpcClientBuilder, IpcError};
 use std::path::PathBuf;
@@ -5,9 +6,11 @@ use std::str::FromStr;
 
 use ethereum_types::{H256, U256};
 use ethportal_api::types::content_key::OverlayContentKey;
+use ethportal_api::HistoryNetworkApiClient;
 use jsonrpsee::{
-    async_client::Client,
-    core::{client::ClientT, params::ArrayParams},
+    async_client::{Client, ClientBuilder},
+    core::client::ClientT,
+    core::params::ArrayParams,
     http_client::{HttpClient, HttpClientBuilder},
     rpc_params,
 };
@@ -18,12 +21,11 @@ use serde_json::{
     Value,
 };
 
-use ethportal_api::utils::bytes::{hex_decode, hex_encode, ByteUtilsError};
-use thiserror::Error;
-use tracing::error;
-use url::Url;
-
 use ethportal_api::types::enr::Enr;
+use ethportal_api::utils::bytes::ByteUtilsError;
+use thiserror::Error;
+use tracing::{error, info};
+use url::Url;
 
 /// Configuration details for connection to a Portal network node.
 #[derive(Clone, Debug)]
@@ -32,32 +34,17 @@ pub enum TransportConfig {
     IPC(PathBuf),
 }
 
-/// Details for a Connection to a Portal network node over different transports.
-pub enum Transport {
-    HTTP(HttpClientManager),
-    IPC(IpcClientManager),
-}
-
-#[derive(Clone, Debug)]
+#[derive(Debug)]
 pub struct PortalApi {
     pub client_url: String,
+    pub client: Client,
 }
 
-#[derive(Clone, Debug)]
+#[derive(Debug)]
 pub struct PortalClient {
     pub api: PortalApi,
     pub client_info: String,
     pub enr: Enr,
-}
-
-/// HTTP-based transport for connecting to a Portal network node.
-pub struct HttpClientManager {
-    client: HttpClient,
-}
-
-/// IPC-based transport for connecting to a Portal network node.
-pub struct IpcClientManager {
-    client: Client,
 }
 
 #[derive(Error, Debug)]
@@ -68,7 +55,7 @@ pub enum JsonRpcError {
     #[error("received empty response (EOF only)")]
     Empty,
 
-    #[error("HTTP client error")]
+    #[error("Client error")]
     HttpClient(#[from] jsonrpsee::core::error::Error),
 
     #[cfg(unix)]
@@ -126,47 +113,6 @@ pub enum JsonRpcError {
     },
 }
 
-#[derive(Debug, Serialize, Deserialize)]
-pub struct JsonRPCResult {
-    id: u32,
-    jsonrpc: String,
-    result: Value,
-}
-
-#[allow(non_snake_case)]
-#[derive(Serialize, Deserialize)]
-pub struct NodeInfo {
-    pub enr: String,
-    pub nodeId: String,
-}
-
-#[allow(non_snake_case)]
-#[derive(Serialize, Deserialize)]
-struct RoutingTableInfoRaw {
-    localKey: String,
-    buckets: Vec<(String, String, String)>,
-}
-
-pub struct RoutingTableEntry {
-    pub node_id: H256,
-    pub enr: Enr,
-    pub status: String,
-    pub distance: U256,
-    pub log_distance: u16,
-}
-
-#[allow(non_snake_case)]
-pub struct RoutingTableInfo {
-    pub localKey: H256,
-    pub buckets: Vec<RoutingTableEntry>,
-}
-
-#[derive(Deserialize)]
-pub struct TracedQueryResult {
-    pub content: String,
-    pub trace: Value,
-}
-
 pub struct Content {
     pub raw: Vec<u8>,
 }
@@ -180,57 +126,24 @@ pub enum PortalResponse {
     Regular(Value),
 }
 
-impl PortalResponse {
-    /// Creates a Portal response from an IPC/HTTP response result.
-    fn from_value(val: Value) -> Self {
-        match val.eq(&json!("0x")) {
-            true => PortalResponse::ContentAbsent,
-            false => PortalResponse::Regular(val),
-        }
-    }
-
-    /// Converts a content response JSON value to a string.
-    ///
-    /// A valid content response may be None, unlike non-content responses.
-    /// This occurs through the special "0x" response defined in the Portal specs.
-    fn content_response_to_string(&self) -> Result<Option<String>, JsonRpcError> {
-        match self {
-            PortalResponse::ContentAbsent => Ok(None),
-            PortalResponse::Regular(response) => match response.as_str() {
-                None | Some("") => Err(JsonRpcError::ContainsNone),
-                Some("0x") => Err(JsonRpcError::SpecialMessageExpected),
-                Some(s) => Ok(Some(s.to_owned())),
-            },
-        }
-    }
-    /// Converts a non-content (e.g., node info) response JSON value to a string.
-    ///
-    /// A valid non-content response may be None, unlike content responses,
-    /// which must use the special "0x" response defined in the Portal specs.
-    fn non_content_response_to_string(&self) -> Result<String, JsonRpcError> {
-        match self {
-            PortalResponse::ContentAbsent => Err(JsonRpcError::SpecialMessageUnexpected),
-            PortalResponse::Regular(r) => Ok(r.to_string()),
-        }
-    }
-}
-
 impl PortalClient {
     pub async fn from(portal_client_url: String) -> Result<Self, JsonRpcError> {
         let api = PortalApi {
             client_url: portal_client_url.clone(),
+            client: PortalApi::parse_client_url(portal_client_url.clone()).await?,
         };
 
-        let client_info = api.get_client_version().await?;
+        let client_info = api
+            .client
+            .client_version()
+            .await
+            .expect("Client version request");
+        info!("Received client info string: {}", client_info);
         let stripped_client_info = strip_quotes(client_info);
 
-        let node_info = &api.get_node_info().await?;
+        let node_info = api.client.node_info().await.expect("Node Info request");
 
-        let enr_string = node_info.enr.clone();
-        let enr: Enr = enr_string.parse().map_err(|err| JsonRpcError::InvalidEnr {
-            error: err,
-            enr_string,
-        })?;
+        let enr = node_info.enr.clone();
 
         Ok(PortalClient {
             api,
@@ -239,192 +152,31 @@ impl PortalClient {
         })
     }
 
-    pub fn is_trin(self) -> bool {
+    pub fn is_trin(&self) -> bool {
         self.client_info.contains("trin")
     }
 }
 
 impl PortalApi {
-    pub async fn make_request(
-        &self,
-        method: &str,
-        params: Option<Vec<Box<RawValue>>>,
-    ) -> Result<PortalResponse, JsonRpcError> {
-        let transport = PortalApi::parse_client_url(self.client_url.clone()).await?;
-        // jsonrpsee requires the conversion of `Option<Vec<Box<RawValue>>>` to `ArrayParams`
-        let array_params: ArrayParams = match params {
-            Some(json_params) => {
-                let mut param_aggregator = rpc_params!();
-                for json_param in json_params {
-                    param_aggregator.insert(json_param).unwrap()
-                }
-                param_aggregator
-            }
-            None => rpc_params!(),
-        };
-        match transport {
-            Transport::HTTP(http) => {
-                let val: Value = http.client.request(method, array_params).await?;
-                Ok(PortalResponse::from_value(val))
-            }
-            Transport::IPC(ipc) => {
-                let val: Value = ipc.client.request(method, array_params).await?;
-                Ok(PortalResponse::from_value(val))
-            }
-        }
-    }
-
-    pub async fn get_client_version(&self) -> Result<String, JsonRpcError> {
-        let method = "web3_clientVersion";
-        let params = None;
-        self.make_request(method, params)
-            .await?
-            .non_content_response_to_string()
-    }
-
-    pub async fn get_node_info(&self) -> Result<NodeInfo, JsonRpcError> {
-        let method = "discv5_nodeInfo";
-        let params = None;
-        let response = self
-            .make_request(method, params)
-            .await?
-            .non_content_response_to_string()?;
-        serde_json::from_str(&response).map_err(|e| JsonRpcError::InvalidJson {
-            source: e,
-            input: response.to_string(),
-        })
-    }
-
-    pub async fn get_routing_table_info(self) -> Result<RoutingTableInfo, JsonRpcError> {
-        let method = "discv5_routingTableInfo";
-        let params = None;
-        let response = self
-            .make_request(method, params)
-            .await?
-            .non_content_response_to_string()?;
-        let result_raw: RoutingTableInfoRaw =
-            serde_json::from_str(&response).map_err(|e| JsonRpcError::InvalidJson {
-                source: e,
-                input: response.to_string(),
-            })?;
-        let local_node_id =
-            H256::from_str(&result_raw.localKey).map_err(|e| JsonRpcError::InvalidHash {
-                source: e,
-                input: result_raw.localKey.to_string(),
-            })?;
-        let buckets: Result<Vec<RoutingTableEntry>, JsonRpcError> = result_raw
-            .buckets
-            .iter()
-            .map(|entry| parse_routing_table_entry(&local_node_id, &entry.0, &entry.1, &entry.2))
-            .collect();
-        Ok(RoutingTableInfo {
-            localKey: local_node_id,
-            buckets: buckets?,
-        })
-    }
-
-    pub async fn get_content<T: OverlayContentKey>(
-        self,
-        content_key: &T,
-    ) -> Result<Option<Content>, JsonRpcError> {
-        let method = "portal_historyRecursiveFindContent";
-        let key = hex_encode(content_key.to_bytes());
-        let param = to_raw_value(&key).map_err(|e| JsonRpcError::InvalidJson {
-            source: e,
-            input: key.to_string(),
-        })?;
-        match self
-            .make_request(method, Some(vec![param]))
-            .await?
-            .content_response_to_string()?
-        {
-            Some(response) => {
-                let content_raw = hex_decode(&response)?;
-                Ok(Some(Content { raw: content_raw }))
-            }
-            None => Ok(None),
-        }
-    }
-
-    pub async fn get_content_with_trace<T: OverlayContentKey>(
-        self,
-        content_key: &T,
-    ) -> Result<(Option<Content>, String), JsonRpcError> {
-        let params = Some(vec![to_raw_value(&hex_encode(content_key.to_bytes()))?]);
-        let resp = self
-            .make_request("portal_historyTraceRecursiveFindContent", params)
-            .await?
-            .non_content_response_to_string()?;
-
-        let query_result: TracedQueryResult = serde_json::from_str(&resp)?;
-        let trace = query_result.trace.to_string();
-        if query_result.content.len() > 2 {
-            let content_raw = hex_decode(&query_result.content)?;
-            Ok((Some(Content { raw: content_raw }), trace))
-        } else {
-            Ok((None, trace))
-        }
-    }
-
-    pub async fn parse_client_url(client_url: String) -> Result<Transport, JsonRpcError> {
+    pub async fn parse_client_url(client_url: String) -> Result<Client, JsonRpcError> {
         let http_prefix = "http://";
         let ipc_prefix = "ipc:///";
-        if client_url.strip_prefix(http_prefix).is_some() {
-            Ok(Transport::HTTP(HttpClientManager {
-                client: HttpClientBuilder::default().build(client_url)?,
-            }))
-        } else if let Some(ipc_path) = client_url.strip_prefix(ipc_prefix) {
+        // if client_url.strip_prefix(http_prefix).is_some() {
+        //     return Ok(HttpClientBuilder::default()
+        //         .build(client_url)
+        //         .expect("Creating HTTP client"));
+        // } else
+        if let Some(ipc_path) = client_url.strip_prefix(ipc_prefix) {
             #[cfg(unix)]
-            return Ok(Transport::IPC(IpcClientManager {
-                client: IpcClientBuilder::default().build(ipc_path).await?,
-            }));
+            return Ok(IpcClientBuilder::default()
+                .build(ipc_path)
+                .await
+                .expect("Creating IPC Client"));
             #[cfg(windows)]
             panic!("Reth doesn't support Unix Domain Sockets IPC for windows, use http")
         } else {
             Err(JsonRpcError::ClientURL { url: client_url })
         }
-    }
-}
-
-fn parse_routing_table_entry(
-    local_node_id: &H256,
-    raw_node_id: &str,
-    encoded_enr: &str,
-    status: &String,
-) -> Result<RoutingTableEntry, JsonRpcError> {
-    let node_id = H256::from_str(raw_node_id).map_err(|e| JsonRpcError::InvalidHash {
-        source: e,
-        input: raw_node_id.to_string(),
-    })?;
-    let enr = Enr::from_str(encoded_enr).map_err(|e| JsonRpcError::InvalidEnr {
-        error: e,
-        enr_string: encoded_enr.to_string(),
-    })?;
-
-    let distance = distance_xor(node_id.as_fixed_bytes(), local_node_id.as_fixed_bytes());
-    let log_distance = distance_log2(distance)?;
-    Ok(RoutingTableEntry {
-        node_id,
-        enr,
-        status: status.to_string(),
-        distance,
-        log_distance,
-    })
-}
-
-fn distance_xor(x: &[u8; 32], y: &[u8; 32]) -> U256 {
-    let mut z: [u8; 32] = [0; 32];
-    for i in 0..32 {
-        z[i] = x[i] ^ y[i];
-    }
-    U256::from_big_endian(z.as_slice())
-}
-
-fn distance_log2(distance: U256) -> Result<u16, JsonRpcError> {
-    if distance.is_zero() {
-        Ok(0)
-    } else {
-        Ok((256 - distance.leading_zeros()).try_into()?)
     }
 }
 


### PR DESCRIPTION
Currently glados uses a custom json rpc client and deserializes the responses to custom types.

This PR integrates a `jsonrpsee` client and replaces custom types with `ethportal_api` types. 

WIP

Implements #123 