### PR TITLE
Expect discv5::enr::NodeId in NodeInfo repsonse

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -31,7 +31,7 @@ checksum = "9e8b47f52ea9bae42228d07ec09eb676433d7c4ed1ebdf0f1d1c29ed446f1ab8"
 dependencies = [
  "cfg-if 1.0.0",
  "cipher",
- "cpufeatures 0.2.5",
+ "cpufeatures 0.2.8",
  "ctr",
  "opaque-debug",
 ]
@@ -883,9 +883,9 @@ dependencies = [
 
 [[package]]
 name = "cpufeatures"
-version = "0.2.5"
+version = "0.2.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "28d997bd5e24a5928dd43e46dc529867e207907fe0b239c3477d924f7f2ca320"
+checksum = "03e69e28e9f7f77debdedbaafa2866e1de9ba56df55a8bd7cfc724c25a09987c"
 dependencies = [
  "libc",
 ]
@@ -997,6 +997,34 @@ dependencies = [
 ]
 
 [[package]]
+name = "curve25519-dalek"
+version = "4.0.0-rc.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "436ace70fc06e06f7f689d2624dc4e2f0ea666efb5aa704215f7249ae6e047a7"
+dependencies = [
+ "cfg-if 1.0.0",
+ "cpufeatures 0.2.8",
+ "curve25519-dalek-derive",
+ "digest 0.10.6",
+ "fiat-crypto",
+ "platforms",
+ "rustc_version 0.4.0",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "curve25519-dalek-derive"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "83fdaf97f4804dcebfa5862639bc9ce4121e82140bec2a987ac5140294865b5b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.12",
+]
+
+[[package]]
 name = "cxx"
 version = "1.0.93"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1073,16 +1101,6 @@ dependencies = [
  "darling_core",
  "quote",
  "syn 1.0.109",
-]
-
-[[package]]
-name = "delay_map"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c4d75d3abfe4830dcbf9bcb1b926954e121669f74dd1ca7aa0183b1755d83f6"
-dependencies = [
- "futures",
- "tokio-util 0.6.10",
 ]
 
 [[package]]
@@ -1170,15 +1188,15 @@ dependencies = [
 
 [[package]]
 name = "discv5"
-version = "0.1.0"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d767c0e59b3e8d65222d95df723cc2ea1da92bb0f27c563607e6f0bde064f255"
+checksum = "b009a99b85b58900df46435307fc5c4c845af7e182582b1fbf869572fa9fce69"
 dependencies = [
  "aes",
  "aes-gcm",
  "arrayvec",
- "delay_map 0.1.2",
- "enr 0.6.2",
+ "delay_map",
+ "enr 0.7.0",
  "fnv",
  "futures",
  "hashlink 0.7.0",
@@ -1203,15 +1221,15 @@ dependencies = [
 
 [[package]]
 name = "discv5"
-version = "0.2.2"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b009a99b85b58900df46435307fc5c4c845af7e182582b1fbf869572fa9fce69"
+checksum = "77f32d27968ba86689e3f0eccba0383414348a6fc5918b0a639c98dd81e20ed6"
 dependencies = [
  "aes",
  "aes-gcm",
  "arrayvec",
- "delay_map 0.3.0",
- "enr 0.7.0",
+ "delay_map",
+ "enr 0.8.1",
  "fnv",
  "futures",
  "hashlink 0.7.0",
@@ -1226,8 +1244,6 @@ dependencies = [
  "smallvec 1.10.0",
  "socket2",
  "tokio",
- "tokio-stream",
- "tokio-util 0.6.10",
  "tracing",
  "tracing-subscriber",
  "uint 0.9.5",
@@ -1274,16 +1290,40 @@ dependencies = [
 ]
 
 [[package]]
+name = "ed25519"
+version = "2.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5fb04eee5d9d907f29e80ee6b0e78f7e2c82342c63e3580d8c4f69d9d5aad963"
+dependencies = [
+ "pkcs8 0.10.1",
+ "signature 2.0.0",
+]
+
+[[package]]
 name = "ed25519-dalek"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c762bae6dcaf24c4c84667b8579785430908723d5c889f469d76a41d59cc7a9d"
 dependencies = [
- "curve25519-dalek",
- "ed25519",
+ "curve25519-dalek 3.2.0",
+ "ed25519 1.5.3",
  "rand 0.7.3",
  "serde",
  "sha2 0.9.9",
+ "zeroize",
+]
+
+[[package]]
+name = "ed25519-dalek"
+version = "2.0.0-rc.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "faa8e9049d5d72bfc12acbc05914731b5322f79b5e2f195e9f2d705fca22ab4c"
+dependencies = [
+ "curve25519-dalek 4.0.0-rc.3",
+ "ed25519 2.2.1",
+ "rand_core 0.6.4",
+ "serde",
+ "sha2 0.10.6",
  "zeroize",
 ]
 
@@ -1343,26 +1383,6 @@ dependencies = [
 
 [[package]]
 name = "enr"
-version = "0.6.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26fa0a0be8915790626d5759eb51fe47435a8eac92c2f212bd2da9aa7f30ea56"
-dependencies = [
- "base64 0.13.1",
- "bs58",
- "bytes",
- "ed25519-dalek",
- "hex",
- "k256 0.11.6",
- "log",
- "rand 0.8.5",
- "rlp 0.5.2",
- "serde",
- "sha3 0.10.6",
- "zeroize",
-]
-
-[[package]]
-name = "enr"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "492a7e5fc2504d5fdce8e124d3e263b244a68b283cac67a69eda0cd43e0aebad"
@@ -1370,7 +1390,7 @@ dependencies = [
  "base64 0.13.1",
  "bs58",
  "bytes",
- "ed25519-dalek",
+ "ed25519-dalek 1.0.1",
  "hex",
  "k256 0.11.6",
  "log",
@@ -1389,6 +1409,7 @@ checksum = "cf56acd72bb22d2824e66ae8e9e5ada4d0de17a69c7fd35569dde2ada8ec9116"
 dependencies = [
  "base64 0.13.1",
  "bytes",
+ "ed25519-dalek 2.0.0-rc.3",
  "hex",
  "k256 0.13.0",
  "log",
@@ -1687,7 +1708,7 @@ dependencies = [
  "ethereum-types 0.12.1",
  "ethnum",
  "hex",
- "jsonrpsee",
+ "jsonrpsee 0.16.2",
  "keccak-hash",
  "lazy_static",
  "quickcheck",
@@ -1744,6 +1765,12 @@ dependencies = [
  "rand_core 0.6.4",
  "subtle",
 ]
+
+[[package]]
+name = "fiat-crypto"
+version = "0.1.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e825f6987101665dea6ec934c09ec6d721de7bc1bf92248e1d5810c8cd636b77"
 
 [[package]]
 name = "fixed-hash"
@@ -2077,14 +2104,15 @@ name = "glados-core"
 version = "0.1.0"
 dependencies = [
  "anyhow",
- "discv5 0.1.0",
+ "discv5 0.3.0",
  "env_logger 0.9.3",
  "ethereum-types 0.14.1",
  "ethportal-api",
  "jsonrpc",
- "jsonrpsee",
- "jsonrpsee-core",
- "jsonrpsee-types",
+ "jsonrpsee 0.18.2",
+ "jsonrpsee-core 0.16.2",
+ "jsonrpsee-types 0.16.2",
+ "reth-ipc",
  "rstest",
  "rustc-hex",
  "serde",
@@ -3054,7 +3082,7 @@ version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3afef3b6eff9ce9d8ff9b3601125eec7f0c8cbac7abd14f355d053fa56c98768"
 dependencies = [
- "cpufeatures 0.2.5",
+ "cpufeatures 0.2.8",
 ]
 
 [[package]]
@@ -3651,6 +3679,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6ac9a59f73473f1b8d852421e59e64809f025994837ef743615c6d0c5b305160"
 
 [[package]]
+name = "platforms"
+version = "3.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3d7ddaed09e0eb771a79ab0fd64609ba0afb0a8366421957936ad14cbd13630"
+
+[[package]]
 name = "polling"
 version = "2.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3673,7 +3707,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8419d2b623c7c0896ff2d5d96e2cb4ede590fed28fcc34934f4c33c036e620a1"
 dependencies = [
  "cfg-if 1.0.0",
- "cpufeatures 0.2.5",
+ "cpufeatures 0.2.8",
  "opaque-debug",
  "universal-hash",
 ]
@@ -4749,7 +4783,7 @@ checksum = "99cd6713db3cf16b6c84e06321e049a9b9f699826e16096d23bbcc44d15d51a6"
 dependencies = [
  "block-buffer 0.9.0",
  "cfg-if 1.0.0",
- "cpufeatures 0.2.5",
+ "cpufeatures 0.2.8",
  "digest 0.9.0",
  "opaque-debug",
 ]
@@ -4761,7 +4795,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f04293dc80c3993519f2d7f6f511707ee7094fe0c6d3406feb330cdb3540eba3"
 dependencies = [
  "cfg-if 1.0.0",
- "cpufeatures 0.2.5",
+ "cpufeatures 0.2.8",
  "digest 0.10.6",
 ]
 
@@ -4773,7 +4807,7 @@ checksum = "4d58a1e1bf39749807d89cf2d98ac2dfa0ff1cb3faa38fbb64dd88ac8013d800"
 dependencies = [
  "block-buffer 0.9.0",
  "cfg-if 1.0.0",
- "cpufeatures 0.2.5",
+ "cpufeatures 0.2.8",
  "digest 0.9.0",
  "opaque-debug",
 ]
@@ -4785,7 +4819,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "82e6b795fe2e3b1e845bafcb27aa35405c4d47cdfc92af5fc8d3002f76cebdc0"
 dependencies = [
  "cfg-if 1.0.0",
- "cpufeatures 0.2.5",
+ "cpufeatures 0.2.8",
  "digest 0.10.6",
 ]
 

--- a/glados-core/Cargo.toml
+++ b/glados-core/Cargo.toml
@@ -10,7 +10,7 @@ authors = ["Piper Merriam <piper@pipermerriam.com>"]
 
 [dependencies]
 anyhow = "1.0.68"
-discv5 = "0.1.0"
+discv5 = { version = "0.3.0", features = ["serde"]}
 ethereum-types = "0.14.0"
 jsonrpc = "0.13.0"
 serde = "1.0.147"

--- a/glados-core/src/jsonrpc.rs
+++ b/glados-core/src/jsonrpc.rs
@@ -3,6 +3,7 @@ use reth_ipc::client::{IpcClientBuilder, IpcError};
 use std::path::PathBuf;
 use std::str::FromStr;
 
+use discv5::enr::NodeId;
 use ethereum_types::{H256, U256};
 use ethportal_api::types::content_key::OverlayContentKey;
 use jsonrpsee::{
@@ -137,7 +138,7 @@ pub struct JsonRPCResult {
 #[derive(Serialize, Deserialize)]
 pub struct NodeInfo {
     pub enr: String,
-    pub nodeId: String,
+    pub nodeId: NodeId,
 }
 
 #[allow(non_snake_case)]


### PR DESCRIPTION
Due to a change in `ethportal_api`, trin's  representation of a NodeId in a `NodeInfo` response changed.

This happening in the future will be avoided once #138 is merged