### PR TITLE
Log invalid content keys & remove duplicate content value log

### DIFF
--- a/glados-audit/src/validation.rs
+++ b/glados-audit/src/validation.rs
@@ -10,7 +10,7 @@ pub fn content_is_valid(content_key: &HistoryContentKey, content_bytes: &[u8]) -
     let content: HistoryContentValue = match HistoryContentValue::decode(content_bytes) {
         Ok(c) => c,
         Err(e) => {
-            warn!(content.value=hex_encode(content_bytes), err=?e, "could not deserialize content bytes");
+            warn!(content.key=content_key.to_hex(), err=?e, "could not deserialize content bytes");
             return false;
         }
     };


### PR DESCRIPTION
Currently when an audit finishes with a payload that can't be validated, the content body is logged (with `WARN`) but not the key.

The value can be inferred from the surrounding context, but that becomes inexact and confusing with all of the concurrency going on. 

The content value is also removed because the errors themselves already contain the content value, so the value was being logged twice. 