### PR TITLE
Adds embedded grafana metrics for trin node

### DIFF
--- a/glados-web/src/lib.rs
+++ b/glados-web/src/lib.rs
@@ -70,6 +70,7 @@ pub async fn run_glados_web(config: Arc<State>) -> Result<()> {
             get(routes::contentkey_detail),
         )
         .route("/audit/id/:audit_id", get(routes::contentaudit_detail))
+        .route("/metrics/", get(routes::metrics))
         .nest_service("/static/", serve_dir.clone())
         .fallback_service(serve_dir)
         .layer(Extension(config));

--- a/glados-web/src/routes.rs
+++ b/glados-web/src/routes.rs
@@ -19,12 +19,11 @@ use sea_orm::{
 use std::sync::Arc;
 use std::{fmt::Display, io};
 use tracing::error;
-use tracing::info;
 
 use crate::templates::{
     ContentAuditDetailTemplate, ContentDashboardTemplate, ContentIdDetailTemplate,
     ContentIdListTemplate, ContentKeyDetailTemplate, ContentKeyListTemplate, EnrDetailTemplate,
-    HtmlTemplate, IndexTemplate, NetworkDashboardTemplate, NodeDetailTemplate,
+    HtmlTemplate, IndexTemplate, MetricsTemplate, NetworkDashboardTemplate, NodeDetailTemplate,
 };
 use crate::{state::State, templates::AuditTuple};
 
@@ -510,12 +509,16 @@ pub async fn contentkey_detail(
     Ok(HtmlTemplate(template))
 }
 
+pub async fn metrics() -> Result<HtmlTemplate<MetricsTemplate>, StatusCode> {
+    let template = MetricsTemplate {};
+    Ok(HtmlTemplate(template))
+}
+
 pub async fn contentaudit_detail(
     Path(audit_id): Path<String>,
     Extension(state): Extension<Arc<State>>,
 ) -> impl IntoResponse {
     let audit_id = audit_id.parse::<i32>().unwrap();
-    info!("Audit ID: {}", audit_id);
     let audit = content_audit::Entity::find_by_id(audit_id)
         .one(&state.database_connection)
         .await

--- a/glados-web/src/templates.rs
+++ b/glados-web/src/templates.rs
@@ -89,6 +89,10 @@ pub struct ContentKeyDetailTemplate {
     pub contentaudit_list: Vec<content_audit::Model>,
 }
 
+#[derive(Template)]
+#[template(path = "local_node_metrics.html")]
+pub struct MetricsTemplate {}
+
 pub struct HtmlTemplate<T: Template>(pub T);
 
 impl<T> IntoResponse for HtmlTemplate<T>

--- a/glados-web/templates/index.html
+++ b/glados-web/templates/index.html
@@ -3,16 +3,19 @@
 {% block title %}Glados{% endblock %}
 
 {% block content %}
-  <div class="row">
+<div class="row">
     <h1>Glados</h1>
-  </div>
-  <div class="row">
+</div>
+<div class="row">
     <div class="col">
-      <a href="/content/">Content Dashboard</a>
+        <a href="/content/">Content Dashboard</a>
     </div>
     <div class="col">
-      <a href="/network/">Network Explorer</a>
+        <a href="/network/">Network Explorer</a>
     </div>
-  </div>
+    <div class="col">
+        <a href="/metrics/">Glados Node Metrics</a>
+    </div>
+</div>
 </div>
 {% endblock %}

--- a/glados-web/templates/local_node_metrics.html
+++ b/glados-web/templates/local_node_metrics.html
@@ -1,0 +1,2 @@
+<iframe style="width: 100%; height: 100%;"
+    src="http://localhost:3000/d/trin-app-metrics/trin-app-metrics?orgId=1&refresh=10s&kiosk=tv&theme=light"></iframe>


### PR DESCRIPTION
Adds a `/metrics/` page that shows the message & storage metrics for glados's associated trin node, if available.

Implements #143 