### PR TITLE
Adds monitoring and auditing of beacon data

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2429,6 +2429,7 @@ dependencies = [
  "migration",
  "reqwest",
  "sea-orm",
+ "serde_json",
  "tokio",
  "tracing",
  "url",

--- a/entity/src/content.rs
+++ b/entity/src/content.rs
@@ -13,6 +13,7 @@ use sea_orm::{entity::prelude::*, ActiveValue::NotSet, Set};
 pub enum SubProtocol {
     History = 0,
     State = 1,
+    Beacon = 2,
 }
 
 impl SubProtocol {
@@ -20,6 +21,7 @@ impl SubProtocol {
         match self {
             SubProtocol::History => "History".to_string(),
             SubProtocol::State => "State".to_string(),
+            SubProtocol::Beacon => "Beacon".to_string(),
         }
     }
 }
@@ -61,6 +63,7 @@ impl Related<super::execution_metadata::Entity> for Entity {
 impl ActiveModelBehavior for ActiveModel {}
 
 pub async fn get_or_create<T: OverlayContentKey>(
+    sub_protocol: SubProtocol,
     content_key: &T,
     available_at: DateTime<Utc>,
     conn: &DatabaseConnection,
@@ -81,8 +84,8 @@ pub async fn get_or_create<T: OverlayContentKey>(
         id: NotSet,
         content_id: Set(content_key.content_id().to_vec()),
         content_key: Set(content_key.to_bytes()),
-        protocol_id: Set(SubProtocol::History),
         first_available_at: Set(available_at),
+        protocol_id: Set(sub_protocol),
     };
     Ok(content_key.insert(conn).await?)
 }

--- a/entity/src/content.rs
+++ b/entity/src/content.rs
@@ -70,7 +70,7 @@ pub async fn get_or_create<T: OverlayContentKey>(
 ) -> Result<Model> {
     // First try to lookup an existing entry.
     if let Some(content_key_model) = Entity::find()
-        .filter(Column::ProtocolId.eq(SubProtocol::History))
+        .filter(Column::ProtocolId.eq(sub_protocol.clone()))
         .filter(Column::ContentKey.eq(content_key.to_bytes()))
         .one(conn)
         .await?
@@ -95,7 +95,6 @@ pub async fn get<T: OverlayContentKey>(
     conn: &DatabaseConnection,
 ) -> Result<Option<Model>> {
     Ok(Entity::find()
-        .filter(Column::ProtocolId.eq(SubProtocol::History))
         .filter(Column::ContentKey.eq(content_key.to_bytes()))
         .one(conn)
         .await?)

--- a/entity/src/test.rs
+++ b/entity/src/test.rs
@@ -124,7 +124,7 @@ async fn test_content_id_as_hash() -> Result<(), DbErr> {
     let (conn, _db) = setup_database().await?;
     let key = sample_history_key();
     let content_id_hash = B256::from_slice(&key.content_id());
-    let content_model = content::get_or_create(&key, Utc::now(), &conn)
+    let content_model = content::get_or_create(SubProtocol::History, &key, Utc::now(), &conn)
         .await
         .unwrap();
     assert_eq!(content_model.id_as_hash(), content_id_hash);
@@ -138,7 +138,7 @@ async fn test_content_id_as_hex() -> Result<(), DbErr> {
     let key = sample_history_key();
     let content_id_hash = B256::from_slice(&key.content_id());
     let content_id_hex = hex_encode(content_id_hash);
-    let content_model = content::get_or_create(&key, Utc::now(), &conn)
+    let content_model = content::get_or_create(SubProtocol::History, &key, Utc::now(), &conn)
         .await
         .unwrap();
     assert_eq!(content_model.id_as_hex(), content_id_hex);
@@ -150,7 +150,7 @@ async fn test_content_id_as_hex() -> Result<(), DbErr> {
 async fn test_content_key_as_hex() -> Result<(), DbErr> {
     let (conn, _db) = setup_database().await?;
     let key = sample_history_key();
-    let content_model = content::get_or_create(&key, Utc::now(), &conn)
+    let content_model = content::get_or_create(SubProtocol::History, &key, Utc::now(), &conn)
         .await
         .unwrap();
     assert_eq!(
@@ -170,7 +170,7 @@ async fn test_content_get_or_create() -> Result<(), DbErr> {
     // Ensure our database is empty
     assert_eq!(content::Entity::find().count(&conn).await?, 0);
 
-    let content_id_a = content::get_or_create(&key, Utc::now(), &conn)
+    let content_id_a = content::get_or_create(SubProtocol::History, &key, Utc::now(), &conn)
         .await
         .unwrap();
 
@@ -178,7 +178,7 @@ async fn test_content_get_or_create() -> Result<(), DbErr> {
     assert_eq!(content::Entity::find().count(&conn).await?, 1);
 
     // Retrieve the key
-    let content_id_b = content::get_or_create(&key, Utc::now(), &conn)
+    let content_id_b = content::get_or_create(SubProtocol::History, &key, Utc::now(), &conn)
         .await
         .unwrap();
 

--- a/glados-audit/src/lib.rs
+++ b/glados-audit/src/lib.rs
@@ -189,6 +189,7 @@ pub async fn run_glados_audit(conn: DatabaseConnection, config: AuditConfig) {
         .expect("failed to pause until ctrl-c");
 
     info!("got CTRL+C. shutting down...");
+    std::process::exit(0);
 }
 
 /// Listens to tasks coming on different strategy channels and selects

--- a/glados-audit/src/lib.rs
+++ b/glados-audit/src/lib.rs
@@ -211,6 +211,8 @@ async fn start_collation(
                     Err(_) => break,
                 }
             }
+            // Limit check for new tasks to 5/sec
+            sleep(Duration::from_millis(200)).await;
         }
     }
 }

--- a/glados-audit/src/selection.rs
+++ b/glados-audit/src/selection.rs
@@ -215,7 +215,7 @@ async fn add_to_queue(
             content_key,
         };
         if let Err(e) = tx.send(task).await {
-            debug!(audit.strategy=?strategy, err=?e, "Could not send key for audit, channel might be full or closed.")
+            error!(audit.strategy=?strategy, err=?e, "Could not send key for audit, channel might be full or closed.")
         }
     }
 }

--- a/glados-audit/src/validation.rs
+++ b/glados-audit/src/validation.rs
@@ -1,16 +1,83 @@
+use entity::content;
 use ethportal_api::utils::bytes::hex_encode;
-use ethportal_api::{BlockHeaderKey, HistoryContentKey, OverlayContentKey};
-use ethportal_api::{ContentValue, HistoryContentValue};
+use ethportal_api::{BeaconContentKey, BlockHeaderKey, HistoryContentKey, OverlayContentKey};
+use ethportal_api::{BeaconContentValue, ContentValue, HistoryContentValue};
 use tracing::warn;
 
 /// Checks that content bytes correspond to a correctly formatted
 /// content value.
-pub fn content_is_valid(content_key: &HistoryContentKey, content_bytes: &[u8]) -> bool {
+pub fn content_is_valid(content: &content::Model, content_bytes: &[u8]) -> bool {
+    match content.protocol_id {
+        content::SubProtocol::History => {
+            let content_key = match HistoryContentKey::try_from(content.content_key.clone()) {
+                Ok(key) => key,
+                Err(err) => {
+                    warn!(err=?err, content.content_key=?content.content_key, "Failed to decode history content key.");
+                    return false;
+                }
+            };
+            validate_history(&content_key, content_bytes)
+        }
+        content::SubProtocol::State => {
+            warn!("State content validation not yet implemented.");
+            true
+        }
+        content::SubProtocol::Beacon => {
+            let content_key = match BeaconContentKey::try_from(content.content_key.clone()) {
+                Ok(key) => key,
+                Err(err) => {
+                    warn!(err=?err, content.content_key=?content.content_key, "Failed to decode beacon content key.");
+                    return false;
+                }
+            };
+            validate_beacon(&content_key, content_bytes)
+        }
+    }
+}
+
+fn validate_beacon(content_key: &BeaconContentKey, content_bytes: &[u8]) -> bool {
+    let content: BeaconContentValue = match BeaconContentValue::decode(content_bytes) {
+        Ok(c) => c,
+        Err(e) => {
+            warn!(content.key=hex_encode(content_key.to_bytes()), err=?e, "could not deserialize beacon content bytes");
+            return false;
+        }
+    };
+
+    match content {
+        BeaconContentValue::HistoricalSummariesWithProof(_) => {
+            warn!("Need to call trusted provider to check historical summaries correctness.");
+            true
+        }
+        BeaconContentValue::LightClientBootstrap(_) => {
+            warn!("Need to call trusted provider to check light client bootstrap correctness.");
+            true
+        }
+        BeaconContentValue::LightClientUpdatesByRange(_) => {
+            warn!(
+                "Need to call trusted provider to check light client updates by range correctness."
+            );
+            true
+        }
+        BeaconContentValue::LightClientOptimisticUpdate(_) => {
+            warn!("Need to call trusted provider to check light client optimistic update correctness.");
+            true
+        }
+        BeaconContentValue::LightClientFinalityUpdate(_) => {
+            warn!(
+                "Need to call trusted provider to check light client finality update correctness."
+            );
+            true
+        }
+    }
+}
+
+fn validate_history(content_key: &HistoryContentKey, content_bytes: &[u8]) -> bool {
     // check deserialization is valid
     let content: HistoryContentValue = match HistoryContentValue::decode(content_bytes) {
         Ok(c) => c,
         Err(e) => {
-            warn!(content.key=content_key.to_hex(), err=?e, "could not deserialize content bytes");
+            warn!(content.key=hex_encode(content_key.to_bytes()), err=?e, "could not deserialize history content bytes");
             return false;
         }
     };

--- a/glados-core/src/db.rs
+++ b/glados-core/src/db.rs
@@ -1,6 +1,9 @@
 use anyhow::Error;
 use chrono::{DateTime, Utc};
-use entity::{content, execution_metadata};
+use entity::{
+    content::{self, SubProtocol},
+    execution_metadata,
+};
 use ethportal_api::{
     utils::bytes::hex_encode, BlockBodyKey, BlockHeaderKey, BlockReceiptsKey, HistoryContentKey,
     OverlayContentKey,
@@ -65,7 +68,7 @@ pub async fn store_content_key<T: OverlayContentKey>(
     conn: &DatabaseConnection,
 ) -> Option<content::Model> {
     // Store key
-    match content::get_or_create(key, available_at, conn).await {
+    match content::get_or_create(SubProtocol::History, key, available_at, conn).await {
         Ok(content_model) => {
             log_record_outcome(key, name, DbOutcome::Success);
             // Store metadata

--- a/glados-core/src/jsonrpc.rs
+++ b/glados-core/src/jsonrpc.rs
@@ -3,7 +3,8 @@ use std::{path::PathBuf, time::Duration};
 
 use alloy_primitives::hex::{self, FromHex};
 use alloy_primitives::{B256, U256};
-use ethportal_api::OverlayContentKey;
+use entity::content;
+// use ethereum_types::{H256, U256};
 use jsonrpsee::{
     core::{client::ClientT, params::ArrayParams},
     http_client::{HttpClient, HttpClientBuilder},
@@ -18,7 +19,7 @@ use serde_json::{
 
 use ethportal_api::utils::bytes::{hex_decode, hex_encode, ByteUtilsError};
 use thiserror::Error;
-use tracing::error;
+use tracing::{error, info};
 use url::Url;
 
 use ethportal_api::types::enr::Enr;
@@ -288,12 +289,16 @@ impl PortalApi {
         })
     }
 
-    pub async fn get_content<T: OverlayContentKey>(
+    pub async fn get_content(
         self,
-        content_key: &T,
+        content: &content::Model,
     ) -> Result<Option<Content>, JsonRpcError> {
-        let method = "portal_historyRecursiveFindContent";
-        let key = hex_encode(content_key.to_bytes());
+        let method = match content.protocol_id {
+            content::SubProtocol::History => "portal_historyRecursiveFindContent",
+            content::SubProtocol::State => "portal_stateRecursiveFindContent",
+            content::SubProtocol::Beacon => "portal_beaconRecursiveFindContent",
+        };
+        let key = hex_encode(content.content_key.clone());
         let param = to_raw_value(&key).map_err(|e| JsonRpcError::InvalidJson {
             source: e,
             input: key.to_string(),
@@ -313,15 +318,20 @@ impl PortalApi {
         }
     }
 
-    pub async fn get_content_with_trace<T: OverlayContentKey>(
+    pub async fn get_content_with_trace(
         self,
-        content_key: &T,
+        content: &content::Model,
     ) -> Result<(Option<Content>, String), JsonRpcError> {
-        let params = Some(vec![to_raw_value(&hex_encode(content_key.to_bytes()))?]);
-        match self
-            .make_request("portal_historyTraceRecursiveFindContent", params)
-            .await
-        {
+        let params = Some(vec![to_raw_value(&hex_encode(
+            content.content_key.clone(),
+        ))?]);
+        let method = match content.protocol_id {
+            content::SubProtocol::History => "portal_historyTraceRecursiveFindContent",
+            content::SubProtocol::State => "portal_stateTraceRecursiveFindContent",
+            content::SubProtocol::Beacon => "portal_beaconTraceRecursiveFindContent",
+        };
+        info!("Making request to method: {}", method);
+        match self.make_request(method, params).await {
             Ok(result) => {
                 let query_result: TracedQueryResult = serde_json::from_str(&result)?;
                 let trace = query_result.trace.to_string();

--- a/glados-monitor/Cargo.toml
+++ b/glados-monitor/Cargo.toml
@@ -21,6 +21,7 @@ tokio = "1.21.2"
 sea-orm = "0.11.3"
 env_logger = "0.9.3"
 futures = "0.3.21"
+serde_json = "1.0.89"
 tracing = "0.1.37"
 ethportal-api = { git = "https://github.com/ethereum/trin" }
 reqwest = { version = "0.11.6", default-features = false, features = ["rustls-tls"] }

--- a/glados-monitor/src/beacon.rs
+++ b/glados-monitor/src/beacon.rs
@@ -1,0 +1,214 @@
+use anyhow::anyhow;
+use chrono::Utc;
+use entity::content::{self, SubProtocol};
+
+use ethportal_api::{
+    types::content_key::beacon::{LightClientFinalityUpdateKey, LightClientOptimisticUpdateKey},
+    utils::bytes::{hex_decode, hex_encode},
+    BeaconContentKey, LightClientBootstrapKey, LightClientUpdatesByRangeKey, OverlayContentKey,
+};
+use reqwest::{header, Client as HttpClient};
+use sea_orm::DatabaseConnection;
+use serde_json::Value;
+use std::{
+    env,
+    time::{Duration, SystemTime, UNIX_EPOCH},
+};
+use tokio::time::sleep;
+use tracing::{debug, error, info};
+
+/// Nimbus node to retrieve beacon data from.
+const PANDA_OPS_BEACON: &str = "https://nimbus.mainnet.ethpandaops.io";
+/// How often the provider will be queried for a new block hash.
+const POLL_PERIOD_SECONDS: u64 = 1;
+// Beacon chain mainnet genesis time: Tue Dec 01 2020 12:00:23 GMT+0000
+pub const BEACON_GENESIS_TIME: u64 = 1606824023;
+
+/// Checks for and stores new Beacon Light Client Bootstrap content keys.
+pub async fn follow_beacon_head(conn: DatabaseConnection, client: HttpClient) {
+    debug!("Getting initial block root");
+    let mut latest_finalized_block_root = get_current_beacon_block_root(&client)
+        .await
+        .expect("Failed to get initial finalized beacon block");
+
+    info!(
+        "Retrieved initial block root: {}",
+        latest_finalized_block_root
+    );
+    store_bootstrap_content_key(&latest_finalized_block_root, conn.clone())
+        .await
+        .expect("Failed to store initial block root");
+
+    loop {
+        debug!("Sleeping for {} seconds", POLL_PERIOD_SECONDS);
+        sleep(Duration::from_secs(POLL_PERIOD_SECONDS)).await;
+
+        debug!("Checking for new finalized block root");
+        let current_finalized_block_root = match get_current_beacon_block_root(&client).await {
+            Ok(block_root) => block_root,
+            Err(e) => {
+                error!(err=?e, "Failed to get current beacon block root");
+                continue;
+            }
+        };
+
+        if current_finalized_block_root != latest_finalized_block_root {
+            latest_finalized_block_root = current_finalized_block_root;
+            info!("New finalized block root: {}", latest_finalized_block_root);
+
+            if let Err(err) =
+                store_bootstrap_content_key(&latest_finalized_block_root, conn.clone()).await
+            {
+                error!("Failed to store bootstrap: {err:?}");
+            }
+        }
+    }
+}
+
+/// Stores a LightClientBootstrap content key for the given block hash if it doesn't already exist.
+async fn store_bootstrap_content_key(hash: &str, conn: DatabaseConnection) -> anyhow::Result<()> {
+    let content_key = BeaconContentKey::LightClientBootstrap(LightClientBootstrapKey {
+        block_hash: <[u8; 32]>::try_from(hex_decode(hash)?).map_err(|err| {
+            anyhow::anyhow!("Failed to convert finalized block root to bytes: {err:?}")
+        })?,
+    });
+
+    match content::get_or_create(SubProtocol::Beacon, &content_key, Utc::now(), &conn).await {
+        Ok(_) => debug!(
+            content.key = hex_encode(content_key.to_bytes()),
+            "Imported new beacon Bootstrap content key",
+        ),
+        Err(err) => return Err(anyhow!("Failed to store bootstrap content key: {}", err)),
+    }
+
+    Ok(())
+}
+
+/// Stores a LightClientOptimisticUpdate content key.
+pub async fn store_lc_optimistic_update(
+    conn: DatabaseConnection,
+    client: &HttpClient,
+) -> anyhow::Result<()> {
+    let content_key = get_lc_optimistic_update_key(client).await?;
+    let content_key = BeaconContentKey::LightClientOptimisticUpdate(content_key);
+
+    match content::get_or_create(SubProtocol::Beacon, &content_key, Utc::now(), &conn).await {
+        Ok(_) => {
+            info!(
+                content.key = hex_encode(content_key.to_bytes()),
+                "Imported new beacon LightClientOptimisticUpdate content key",
+            );
+            Ok(())
+        }
+        Err(err) => Err(anyhow!(
+            "Failed to store LC optimistic update content key: {}",
+            err
+        )),
+    }
+}
+
+/// Stores a LightClientUpdatesByRange content key for the current period if one doesnt already exist.
+pub async fn store_lc_update_by_range(conn: DatabaseConnection) -> anyhow::Result<()> {
+    let expected_period = expected_current_period();
+
+    let content_key = BeaconContentKey::LightClientUpdatesByRange(LightClientUpdatesByRangeKey {
+        start_period: expected_period,
+        count: 1,
+    });
+
+    match content::get_or_create(SubProtocol::Beacon, &content_key, Utc::now(), &conn).await {
+        Ok(_) => {
+            debug!(
+                content.key = hex_encode(content_key.to_bytes()),
+                "Imported new beacon LightClientUpdatesByRange content key",
+            );
+            Ok(())
+        }
+        Err(err) => Err(anyhow!(
+            "Failed to store LC update by range content key: {}",
+            err
+        )),
+    }
+}
+
+/// Retrieve the latest finalized block root from the beacon node.
+async fn get_current_beacon_block_root(client: &HttpClient) -> anyhow::Result<String> {
+    let url = format!("{}/eth/v1/beacon/blocks/finalized/root", PANDA_OPS_BEACON);
+    let response = client.get(url).send().await?.text().await?;
+    let response: Value = serde_json::from_str(&response)?;
+    let latest_finalized_block_root: String =
+        serde_json::from_value(response["data"]["root"].clone())?;
+    Ok(latest_finalized_block_root)
+}
+
+/// Requests the latest `LightClientOptimisticUpdateKey` known by the server.
+pub async fn get_lc_optimistic_update_key(
+    client: &HttpClient,
+) -> anyhow::Result<LightClientOptimisticUpdateKey> {
+    let url = format!(
+        "{}/eth/v1/beacon/light_client/optimistic_update",
+        PANDA_OPS_BEACON
+    );
+    let response = client.get(url).send().await?.text().await?;
+    let update: Value = serde_json::from_str(&response)?;
+
+    let signature_slot = update["data"]["signature_slot"]
+        .as_str()
+        .ok_or(anyhow!("signature_slot is not a string"))?;
+    let signature_slot: u64 = signature_slot
+        .parse()
+        .map_err(|_| anyhow!("Failed to parse signature_slot as u64"))?;
+
+    let update: LightClientOptimisticUpdateKey =
+        LightClientOptimisticUpdateKey::new(signature_slot);
+
+    Ok(update)
+}
+
+/// Gets the latest `LightClientFinalityUpdateKey` known by the server.
+pub async fn get_lc_finality_update_key(
+    client: &HttpClient,
+) -> anyhow::Result<LightClientFinalityUpdateKey> {
+    let url = format!(
+        "{}/eth/v1/beacon/light_client/finality_update",
+        PANDA_OPS_BEACON
+    );
+    let response = client.get(url).send().await?.text().await?;
+    let update: Value = serde_json::from_str(&response)?;
+
+    let signature_slot = update["data"]["signature_slot"]
+        .as_str()
+        .ok_or(anyhow!("signature_slot is not a string"))?;
+    let signature_slot: u64 = signature_slot
+        .parse()
+        .map_err(|_| anyhow!("Failed to parse signature_slot as u64"))?;
+    let update: LightClientFinalityUpdateKey = LightClientFinalityUpdateKey::new(signature_slot);
+    Ok(update)
+}
+
+/// Creates a reqwest::Client configured for PandaOps auth.
+pub fn panda_ops_http() -> anyhow::Result<HttpClient> {
+    let mut headers = header::HeaderMap::new();
+    let client_id = env::var("PANDAOPS_CLIENT_ID")
+        .map_err(|_| anyhow!("PANDAOPS_CLIENT_ID env var not set."))?;
+    let client_id = header::HeaderValue::from_str(&client_id);
+    let client_secret = env::var("PANDAOPS_CLIENT_SECRET")
+        .map_err(|_| anyhow!("PANDAOPS_CLIENT_SECRET env var not set."))?;
+    let client_secret = header::HeaderValue::from_str(&client_secret);
+    headers.insert("CF-Access-Client-Id", client_id?);
+    headers.insert("CF-Access-Client-Secret", client_secret?);
+
+    match reqwest::Client::builder().default_headers(headers).build() {
+        Ok(client) => Ok(client),
+        Err(e) => Err(anyhow!("Failed to build http client: {}", e)),
+    }
+}
+
+/// Calculates the expected current beacon period based on the current time.
+fn expected_current_period() -> u64 {
+    let now = SystemTime::now();
+    let now = now.duration_since(UNIX_EPOCH).expect("Time went backwards");
+    let since_genesis = now - std::time::Duration::from_secs(BEACON_GENESIS_TIME);
+
+    since_genesis.as_secs() / 12 / (32 * 256)
+}

--- a/glados-monitor/src/cli.rs
+++ b/glados-monitor/src/cli.rs
@@ -30,6 +30,8 @@ pub enum Commands {
         provider_url: String,
     },
 
+    FollowBeaconPandaops {},
+
     /// does testing things
     ImportPreMergeAccumulators {
         /// lists test values

--- a/glados-monitor/src/lib.rs
+++ b/glados-monitor/src/lib.rs
@@ -4,6 +4,7 @@ use std::time::Duration;
 use alloy_primitives::B256;
 use anyhow::{anyhow, Result};
 use chrono::{DateTime, TimeZone, Utc};
+use entity::content::SubProtocol;
 use ethportal_api::utils::bytes::hex_decode;
 use ethportal_api::{EpochAccumulatorKey, HistoryContentKey};
 use futures::future::join_all;
@@ -20,10 +21,13 @@ use web3::transports::Http;
 use web3::types::BlockId;
 use web3::Web3;
 
+use crate::beacon::follow_beacon_head;
+use reqwest::Client as HttpClient;
 use url::Url;
 
 use entity::content;
 
+pub mod beacon;
 pub mod cli;
 
 pub async fn run_glados_monitor(conn: DatabaseConnection, w3: web3::Web3<web3::transports::Http>) {
@@ -31,6 +35,17 @@ pub async fn run_glados_monitor(conn: DatabaseConnection, w3: web3::Web3<web3::t
 
     tokio::spawn(follow_chain_head(w3.clone(), tx));
     tokio::spawn(retrieve_new_blocks(w3.clone(), rx, conn));
+
+    debug!("setting up CTRL+C listener");
+    tokio::signal::ctrl_c()
+        .await
+        .expect("failed to pause until ctrl-c");
+
+    info!("got CTRL+C. shutting down...");
+}
+
+pub async fn run_glados_monitor_beacon(conn: DatabaseConnection, client: HttpClient) {
+    tokio::spawn(follow_beacon_head(conn, client));
 
     debug!("setting up CTRL+C listener");
     tokio::signal::ctrl_c()
@@ -181,8 +196,13 @@ pub async fn import_pre_merge_accumulators(
                                         epoch_hash: B256::from_slice(&content_key_raw[1..]),
                                     });
                                 debug!(content_key = %content_key, "Importing");
-                                let content_key_db =
-                                    content::get_or_create(&content_key, Utc::now(), &conn).await?;
+                                let content_key_db = content::get_or_create(
+                                    SubProtocol::History,
+                                    &content_key,
+                                    Utc::now(),
+                                    &conn,
+                                )
+                                .await?;
                                 info!(content_key = %content_key, database_id = content_key_db.id, "Imported");
                             }
                             Err(_) => info!(

--- a/glados-monitor/src/main.rs
+++ b/glados-monitor/src/main.rs
@@ -1,15 +1,15 @@
 use anyhow::Result;
 use clap::Parser;
+use glados_monitor::{
+    beacon::panda_ops_http,
+    bulk_download_block_data,
+    cli::{Cli, Commands},
+    import_pre_merge_accumulators, panda_ops_web3, run_glados_monitor, run_glados_monitor_beacon,
+};
+use migration::{Migrator, MigratorTrait};
 use sea_orm::{Database, DatabaseConnection};
 use tokio::{signal, task};
 use tracing::{debug, info};
-
-use glados_monitor::{
-    bulk_download_block_data,
-    cli::{Cli, Commands},
-    import_pre_merge_accumulators, panda_ops_web3, run_glados_monitor,
-};
-use migration::{Migrator, MigratorTrait};
 
 #[tokio::main]
 async fn main() -> Result<()> {
@@ -57,6 +57,9 @@ async fn main() -> Result<()> {
         Some(Commands::ImportPreMergeAccumulators { path }) => {
             info!("Importing pre-merge accumulators");
             task::spawn(import_pre_merge_accumulators(conn, path.to_path_buf()))
+        }
+        Some(Commands::FollowBeaconPandaops {}) => {
+            task::spawn(follow_beacon_command_pandaops(conn))
         }
         Some(Commands::BulkDownloadBlockData {
             start_block_number,
@@ -121,6 +124,12 @@ async fn follow_head_command(conn: DatabaseConnection, provider_url: String) -> 
     );
 
     run_glados_monitor(conn, w3).await;
+    Ok(())
+}
+
+async fn follow_beacon_command_pandaops(conn: DatabaseConnection) -> Result<()> {
+    let http_client = panda_ops_http()?;
+    run_glados_monitor_beacon(conn, http_client).await;
     Ok(())
 }
 

--- a/glados-monitor/src/main.rs
+++ b/glados-monitor/src/main.rs
@@ -51,7 +51,7 @@ async fn main() -> Result<()> {
             task::spawn(follow_head_command(conn, provider_url.to_string()))
         }
         Some(Commands::FollowHeadPandaops { provider_url }) => {
-            info!("Running follow head");
+            info!("Running follow head beacon");
             task::spawn(follow_head_command_pandaops(conn, provider_url.to_string()))
         }
         Some(Commands::ImportPreMergeAccumulators { path }) => {


### PR DESCRIPTION
This PR adds glados support for beacon data.

Changes:

- Adds `glados-monitor follow-beacon-head` command
- Modifies `glados-audit` to audit content keys from any portal overlay (previously any content key would parsed as a `HistoryContentKey` and be passed to a `portal_history...` endpoint), including state and beacon. 
