### PR TITLE
Adds hourly success rate API route for glados bot integration

### DIFF
--- a/glados-web/src/lib.rs
+++ b/glados-web/src/lib.rs
@@ -70,6 +70,10 @@ pub async fn run_glados_web(config: Arc<State>) -> Result<()> {
             get(routes::contentkey_detail),
         )
         .route("/audit/id/:audit_id", get(routes::contentaudit_detail))
+        .route(
+            "/api/hourly-success-rate/",
+            get(routes::hourly_success_rate),
+        )
         .nest_service("/static/", serve_dir.clone())
         .fallback_service(serve_dir)
         .layer(Extension(config));


### PR DESCRIPTION
Adds glados API route `/api/hourly_success_rate` for the purpose of integrating a discord bot to alert us when success rate drops.

Returns just a single JSON float value representing the percentage of success, or an error message on error if one occurs. 