### PR TITLE
allow trace requests for fluffy

### DIFF
--- a/glados-audit/src/lib.rs
+++ b/glados-audit/src/lib.rs
@@ -264,7 +264,7 @@ async fn perform_single_audit(
         client.url = client.api.client_url.clone(),
         "auditing content",
     );
-    let (content_response, trace) = if client.clone().is_trin() {
+    let (content_response, trace) = if client.clone().supports_trace() {
         match client.api.get_content_with_trace(&task.content_key).await {
             Ok(c) => c,
             Err(e) => {

--- a/glados-core/src/jsonrpc.rs
+++ b/glados-core/src/jsonrpc.rs
@@ -246,8 +246,8 @@ impl PortalClient {
         })
     }
 
-    pub fn is_trin(self) -> bool {
-        self.client_info.contains("trin")
+    pub fn supports_trace(self) -> bool {
+        self.client_info.contains("trin") || self.client_info.contains("fluffy")
     }
 }
 

--- a/glados-web/assets/css/trace.css
+++ b/glados-web/assets/css/trace.css
@@ -96,6 +96,10 @@
     background: #956955;
 }
 
+#cancelled {
+  background: #edc949;
+}
+
 .previous {
     margin-left: 10px;
 }

--- a/glados-web/assets/js/trace/enr.js
+++ b/glados-web/assets/js/trace/enr.js
@@ -37,7 +37,6 @@
                     exports.ENR = void 0;
                     const RLP = __importStar(require("rlp"));
                     const base64url_1 = __importDefault(require("base64url"));
-                    const convert_1 = __importStar("@multiformats/multiaddr/convert");
                     class ENR extends Map {
                         _nodeId;
                         constructor(kvs = {}) {
@@ -81,7 +80,7 @@
                         get ip() {
                             const raw = this.get("ip");
                             if (raw) {
-                                return (0, convert_1.convertToString)("ip4", toNewUint8Array(raw));
+                                return toNewUint8Array(raw).reduce((acc, n) => {acc.push(n); return acc;}, []).join(".")
                             }
                             else {
                                 return undefined;
@@ -90,7 +89,7 @@
                         get udp() {
                             const raw = this.get("udp");
                             if (raw) {
-                                return Number((0, convert_1.convertToString)("udp", toNewUint8Array(raw)));
+                                return (new DataView(toNewUint8Array(raw).buffer)).getInt16();
                             }
                             else {
                                 return undefined;

--- a/glados-web/assets/js/trace/main.js
+++ b/glados-web/assets/js/trace/main.js
@@ -31,7 +31,7 @@ function createGraphData(trace) {
 
     if (Object.keys(trace).length === 0) {
         return {
-            nodes: [{ id: "local", group: colors.orange, timestamp: 0 }],
+            nodes: [{ id: "local", group: colors.orange, durationMs: 0 }],
             links: [],
         }
     }
@@ -70,7 +70,7 @@ function createGraphData(trace) {
     Object.keys(responses).forEach((nodeId, _) => {
 
         let node = responses[nodeId];
-        let timestamp = node.duration;
+        let durationMs = node.durationMs;
         let respondedWith = node.respondedWith;
         if (!Array.isArray(respondedWith)) {
             return;
@@ -92,8 +92,8 @@ function createGraphData(trace) {
             }
             nodes.push({
                 id: nodeId,
-                group: group,
-                timestamp: timestamp,
+                group,
+                durationMs,
                 ...metadata[nodeId]
             });
             nodesSeen.push(nodeId);
@@ -188,11 +188,11 @@ function computeSuccessfulRoute(trace) {
 // Generates a string to appear on hover-over of a node.
 function generateNodeMetadata(node) {
 
-    let timestamp = node.timestamp;
+    let durationMs = node.durationMs;
     let client = node.client;
     let metadata = `${node.id}\n`;
-    if (timestamp !== undefined) {
-        metadata += `${timestamp} ms\n`;
+    if (durationMs !== undefined) {
+        metadata += `${durationMs} ms\n`;
     }
     if (client !== undefined) {
         metadata += `${client}`;

--- a/glados-web/assets/js/trace/main.js
+++ b/glados-web/assets/js/trace/main.js
@@ -15,13 +15,13 @@ function createGraph(graphData) {
 }
 
 const colors = {
-    blue: 0,
-    orange: 1,
-    red: 2,
-    green: 4,
-    brown: 8,
-    gray: 9,
-
+    blue   : 0,
+    orange : 1,
+    red    : 2,
+    green  : 4,
+    yellow : 5,
+    brown  : 8,
+    gray   : 9,
 };
 
 // Converts json response to format expected by D3 ForceGraph:
@@ -41,99 +41,97 @@ function createGraphData(trace) {
     console.log('Route:');
     console.log(successfulRoute);
 
+    let metadata = {};
+    Object.keys(trace.metadata).forEach((nodeId) => {
+      let meta = trace.metadata[nodeId];
+      let enr = meta.enr;
+      let decodedEnr = ENR.ENR.decodeTxt(enr);
+
+      let ip = decodedEnr.ip || "localhost"; // Edge case for local node
+      let port = decodedEnr.udp;
+      let distance = BigInt(meta.distance);
+      let distanceLog2 = bigLog2(distance);
+      let client = decodedEnr.client;
+
+      metadata[nodeId] = {
+        enr,
+        ip,
+        port,
+        distance,
+        distanceLog2,
+        client
+      }
+    });
+
     // Create nodes.
     let nodes = [];
     let nodesSeen = [];
     let responses = trace.responses;
-    let trinNodesResponded = 0;
-    let trinNodesNoResponse = 0;
-    Object.keys(responses).forEach((node_id, _) => {
+    Object.keys(responses).forEach((nodeId, _) => {
 
-        let node = responses[node_id];
-        let timestamp = node.timestamp_ms;
-        let respondedWith = node.responded_with;
+        let node = responses[nodeId];
+        let timestamp = node.duration;
+        let respondedWith = node.respondedWith;
         if (!Array.isArray(respondedWith)) {
             return;
         }
-        if (!nodesSeen.includes(node_id)) {
+        if (!nodesSeen.includes(nodeId)) {
             let group = 0;
-            if ('origin' in trace && trace.origin == node_id) {
+            if ('origin' in trace && trace.origin == nodeId) {
                 group = colors.orange;
             } else {
-                if ('received_content_from_node' in trace && trace.received_content_from_node == node_id) {
+                if ('receivedFrom' in trace && trace.receivedFrom == nodeId) {
                     group = colors.green;
                 } else if (respondedWith.length == 0) {
                     group = colors.brown;
+                } else if (trace.cancelled.includes(nodeId)) {
+                    group = colors.yellow;
                 } else {
                     group = colors.blue;
                 }
             }
-            let metadata = trace.node_metadata[node_id];
-            let enr = metadata.enr;
-            let ip = metadata.ip;
-            let port = metadata.port;
-            let distance_to_content = metadata.distance_to_content;
-            let distance_log2 = metadata.distance_log2;
-            let node_id_full = metadata.node_id;
-            let client = ENR.ENR.decodeTxt(enr).client;
-            if (client === 'trin') { trinNodesResponded++ }
             nodes.push({
-                id: node_id,
-                enr: enr,
+                id: nodeId,
                 group: group,
                 timestamp: timestamp,
-                ip: ip,
-                port: port,
-                distance: distance_to_content,
-                distance_log2,
-                node_id: node_id_full,
-                client: client
+                ...metadata[nodeId]
             });
-            nodesSeen.push(node_id);
+            nodesSeen.push(nodeId);
         }
     });
 
     // Create links.
     let links = [];
-    Object.keys(responses).forEach((node_id_source, _) => {
+    Object.keys(responses).forEach((nodeIdSource, _) => {
 
-        let node = responses[node_id_source];
-        let responded_with = node.responded_with;
-        if (!Array.isArray(responded_with)) {
+        let node = responses[nodeIdSource];
+        let respondedWith = node.respondedWith;
+        if (!Array.isArray(respondedWith)) {
             return;
         }
-        responded_with.forEach((node_id_target, _) => {
-            if (!nodesSeen.includes(node_id_target)) {
-                let metadata = trace.node_metadata[node_id_target];
-                let enr = metadata.enr;
-                let ip = metadata.ip;
-                let port = metadata.port;
-                let distance_to_content = metadata.distance_to_content;
-                let distance_log2 = metadata.distance_log2;
-                let node_id = metadata.node_id;
-                let client = ENR.ENR.decodeTxt(enr).client;
-                if (client === 'trin') { trinNodesNoResponse++ }
+        respondedWith.forEach((nodeIdTarget, _) => {
+            if (!nodesSeen.includes(nodeIdTarget)) {
+                let group = colors.gray;
+
+                if (trace.cancelled.includes(nodeIdTarget)) {
+                  group = colors.yellow
+                }
+
                 nodes.push({
-                    id: node_id_target,
-                    enr: enr,
-                    group: colors.gray,
-                    ip: ip,
-                    port: port,
-                    distance: distance_to_content,
-                    distance_log2,
-                    node_id: node_id,
-                    client: client
+                    id: nodeIdTarget,
+                    group: group,
+                    ...metadata[nodeIdTarget]
                 });
-                nodesSeen.push(node_id_target)
+                nodesSeen.push(nodeIdTarget)
             }
             let value = 1;
-            if (successfulRoute.includes(node_id_source)
-                && successfulRoute.includes(node_id_target)) {
+            if (successfulRoute.includes(nodeIdSource)
+                && successfulRoute.includes(nodeIdTarget)) {
                 value = 40;
             }
             links.push({
-                source: node_id_source,
-                target: node_id_target,
+                source: nodeIdSource,
+                target: nodeIdTarget,
                 value: value
             })
         })
@@ -143,9 +141,7 @@ function createGraphData(trace) {
         links: links,
         metadata: {
             nodesContacted: nodes.length - 1,
-            nodesResponded: Object.keys(responses).length - 1,
-            trinNodesContacted: trinNodesResponded + trinNodesNoResponse,
-            trinNodesResponded: trinNodesResponded,
+            nodesResponded: Object.keys(responses).length - 1
         }
     }
     return graph;
@@ -156,33 +152,31 @@ function createGraphData(trace) {
 // Starts from the end (where the content was found) and finds the way back to the origin.
 function computeSuccessfulRoute(trace) {
 
-    if (!('origin' in trace && 'received_content_from_node' in trace)) {
+    if (!('origin' in trace && 'receivedFrom' in trace)) {
         return [];
     }
 
     let origin = trace.origin;
-    let found_at = trace.received_content_from_node;
+    let receivedFrom = trace.receivedFrom;
 
     let route = [];
-    // Find the node that contains found_at.
-    let target_node = found_at;
-    route.push(target_node);
+    route.push(receivedFrom);
     let route_info = trace.responses;
-    while (target_node != origin) {
+    while (receivedFrom != origin) {
 
-        let previous_target = target_node;
-        Object.keys(route_info).forEach((node_id, _) => {
+        let previous_target = receivedFrom;
+        Object.keys(route_info).forEach((nodeId, _) => {
 
-            let node = route_info[node_id];
-            let responses = node.responded_with;
+            let node = route_info[nodeId];
+            let responses = node.respondedWith;
 
             // Find the node that responded with the current target node.
-            if (Array.isArray(responses) && responses.includes(target_node)) {
-                target_node = node_id;
-                route.push(target_node);
+            if (Array.isArray(responses) && responses.includes(receivedFrom)) {
+                receivedFrom = nodeId;
+                route.push(receivedFrom);
             }
         })
-        if (previous_target == target_node) {
+        if (previous_target == receivedFrom) {
             // Did not progress, no route found.
             return [];
         }
@@ -208,21 +202,20 @@ function generateNodeMetadata(node) {
 }
 
 function generateTable(nodes) {
-
-    nodes.sort((a, b) => a.distance - b.distance);
+    nodes.sort((a, b) => a.distance < b.distance ? -1 : (a.distance > b.distance) ? 1 : 0);
     nodes.forEach((node, index) => {
 
-        let node_id_string = node.id;
-        node_id_string = node_id_string.substr(0, 6)
-            + '...' + node_id_string.substr(node_id_string.length - 4, node_id_string.length);
+        let nodeIdString = node.id;
+        nodeIdString = nodeIdString.substr(0, 6)
+            + '...' + nodeIdString.substr(nodeIdString.length - 4, nodeIdString.length);
 
         let enr_shortened = node.enr.substr(5, 4) + '...' + node.id.substr(node.id.length - 5, node.id.length);
 
         let tr = document.createElement("tr");
         tr.innerHTML = `<th scope="row">${index + 1}</th>
             <td>${enr_shortened}</td>
-            <td>${node_id_string}</td>
-            <td>${node.distance_log2}</td>
+            <td>${nodeIdString}</td>
+            <td>${node.distanceLog2}</td>
             <td>${node.ip}:${node.port}</td>
             <td>${node.client === undefined ? "" : node.client}</td>`;
 
@@ -271,3 +264,17 @@ function unHighlight() {
     $('tr').css('background-color', 'white');
 
 }
+
+function bigLog2(num) {
+  const one = BigInt(1);
+  let ret = BigInt(0);
+
+  while (num>>=one) ret++
+
+  return ret;
+}
+
+function supportsTrace(client) {
+  client === 'trin' | client === 'fluffy'
+}
+

--- a/glados-web/templates/contentaudit_detail.html
+++ b/glados-web/templates/contentaudit_detail.html
@@ -4,7 +4,6 @@
 
 {% block content %}
 <script src="/static/js/d3.min.js"></script>
-<script src="https://unpkg.com/@multiformats/multiaddr/dist/index.min.js"></script>
 <script src="/static/js/trace/enr.js"></script>
 <script src="/static/js/trace/graph.js"></script>
 <script src="/static/js/trace/main.js"></script>
@@ -23,29 +22,6 @@
         </div>
     </div>
     <div id="no-trace" hidden="true">No Trace Available</div>
-    <div class="row" id="metadata">
-        <div class="col">
-            <text>Nodes Contacted:</text>
-            <text id="nodes-contacted"> </text>
-            </br>
-            <text>Response Rate:</text>
-            <text id="nodes-responded"></text>
-        </div>
-        <div class="col">
-            <text>Trin Nodes Contacted:</text>
-            <text id="trin-nodes-contacted"></text>
-            </br>
-            <text>Trin Nodes Response Rate:</text>
-            <text id="trin-nodes-responded"></text>
-        </div>
-        <div class="col">
-            <text>Non-Trin Nodes Contacted:</text>
-            <text id="non-trin-nodes-contacted"></text>
-            </br>
-            <text>Non-Trin Nodes Response Rate:</text>
-            <text id="non-trin-nodes-responded"></text>
-        </div>
-    </div>
 </div>
 
 <div id="trace" class="row">

--- a/glados-web/templates/contentaudit_detail.html
+++ b/glados-web/templates/contentaudit_detail.html
@@ -4,6 +4,7 @@
 
 {% block content %}
 <script src="/static/js/d3.min.js"></script>
+<script src="https://unpkg.com/@multiformats/multiaddr/dist/index.min.js"></script>
 <script src="/static/js/trace/enr.js"></script>
 <script src="/static/js/trace/graph.js"></script>
 <script src="/static/js/trace/main.js"></script>
@@ -60,6 +61,8 @@
             <text>No Progress</text>
             <div class="legend-dot" id="found-content"></div>
             <text>Content Found</text>
+            <div class="legend-dot" id="cancelled"></div>
+            <text>Request Cancelled</text>
         </div>
 
     </div>
@@ -87,9 +90,7 @@
 <script>
     $(document).ready(function () {
 
-        try {
             let trace_string = "{{ audit.trace }}".replace(/&quot;/g, '"');
-            console.log(trace_string);
             let trace = JSON.parse(trace_string);
 
             let heightTaken = $('#top-of-audit-detail').height();
@@ -102,20 +103,6 @@
 
             generateTable(graphData.nodes);
 
-            let metadata = graphData.metadata;
-            let nodesResponded = metadata.nodesResponded / metadata.nodesContacted;
-            $('#nodes-contacted').text(metadata.nodesContacted);
-            $('#nodes-responded').text(Math.round(nodesResponded * 100) + '%');
-
-            let trinNodesResponded = metadata.trinNodesResponded / metadata.trinNodesContacted;
-            $('#trin-nodes-contacted').text(metadata.trinNodesContacted);
-            $('#trin-nodes-responded').text(Math.round(trinNodesResponded * 100) + '%');
-
-            let nonTrinNodesContacted = metadata.nodesContacted - metadata.trinNodesContacted;
-            let nonTrinNodesResponseRate = (metadata.nodesResponded - metadata.trinNodesResponded) / nonTrinNodesContacted;
-            $('#non-trin-nodes-contacted').text(nonTrinNodesContacted);
-            $('#non-trin-nodes-responded').text(Math.round(nonTrinNodesResponseRate * 100) + '%');
-
             $('#trin-button').on("mouseenter", function () {
                 $('#trin-button').css('background-color', 'lightgray');
                 highlightTrinNodes();
@@ -123,12 +110,6 @@
                 $('#trin-button').css('background-color', 'white');
                 unHighlight();
             });
-        } catch (e) {
-            console.error(e);
-            $('#no-trace').attr('hidden', false);
-            $('#metadata').attr('hidden', true);
-            $('#trace').attr('hidden', true);
-        }
     });
 </script>
 


### PR DESCRIPTION
Allow trace feature for Fluffy and (potentially) other clients.
+ removed unused fields
+ all `snake_case` fields renamed to `camelCase`
+ ENR decoder for port and ip
+ support for displaying cancelled requests

Here's spec update: https://github.com/ethereum/portal-network-specs/pull/236