### PR TITLE
feat: api to check if content is in deadzone or will be accepted by network

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2181,7 +2181,7 @@ dependencies = [
  "enr 0.8.1",
  "entity",
  "env_logger 0.9.3",
- "ethereum-types 0.14.1",
+ "ethereum-types 0.12.1",
  "ethportal-api",
  "glados-core",
  "itertools",

--- a/glados-web/Cargo.toml
+++ b/glados-web/Cargo.toml
@@ -17,7 +17,7 @@ clap = { version = "4.0.26", features = ["derive"] }
 enr = { version = "0.8.1", features = ["k256", "ed25519"] }
 entity = { path = "../entity" }
 env_logger = "0.9.3"
-ethereum-types = "0.14.0"
+ethereum-types = "0.12.1"
 ethportal-api = "0.2.2"
 glados-core = { path = "../glados-core" }
 migration = { path = "../migration" }

--- a/glados-web/src/lib.rs
+++ b/glados-web/src/lib.rs
@@ -81,6 +81,10 @@ pub async fn run_glados_web(config: Arc<State>) -> Result<()> {
             "/api/hourly-success-rate/",
             get(routes::hourly_success_rate),
         )
+        .route(
+            "/is-content-in-deadzone/:content_key",
+            get(routes::is_content_in_deadzone),
+        )
         .nest_service("/static/", serve_dir.clone())
         .fallback_service(serve_dir)
         .layer(Extension(config));

--- a/glados-web/src/lib.rs
+++ b/glados-web/src/lib.rs
@@ -82,7 +82,7 @@ pub async fn run_glados_web(config: Arc<State>) -> Result<()> {
             get(routes::hourly_success_rate),
         )
         .route(
-            "/is-content-in-deadzone/:content_key",
+            "/api/is-content-in-deadzone/:content_key",
             get(routes::is_content_in_deadzone),
         )
         .nest_service("/static/", serve_dir.clone())

--- a/glados-web/src/routes.rs
+++ b/glados-web/src/routes.rs
@@ -15,7 +15,7 @@ use ethportal_api::jsonrpsee::core::__reexports::serde_json;
 use ethportal_api::types::distance::{Distance, Metric, XorMetric};
 use ethportal_api::utils::bytes::{hex_decode, hex_encode};
 use ethportal_api::{HistoryContentKey, OverlayContentKey};
-use migration::{Alias, JoinType};
+use migration::{Alias, JoinType, Order};
 use sea_orm::sea_query::{Expr, Query, SeaRc};
 use sea_orm::{
     ColumnTrait, ConnectionTrait, DatabaseConnection, DbBackend, DynIden, EntityTrait,
@@ -105,8 +105,8 @@ pub async fn root(Extension(state): Extension<Arc<State>>) -> impl IntoResponse 
                     } else {
                         "convert_from(key, 'UTF8')"
                     })
-                    // Uses a CAST to TEXT on the table in order to do a comparison to the binary value, both SQLite and Postgres both need to be casted in order to be compared
-                    .eq("c"),
+                        // Uses a CAST to TEXT on the table in order to do a comparison to the binary value, both SQLite and Postgres both need to be casted in order to be compared
+                        .eq("c"),
                 )
                 .take(),
             right_table.clone(),
@@ -392,12 +392,12 @@ pub async fn get_audits_for_recent_content(
             .unzip();
 
     let client_info = audits
-            .load_one(client_info::Entity, conn)
-            .await
-            .map_err(|e| {
-                error!(key.count=audits.len(), err=?e, "Could not look up client info for recent audits");
-                StatusCode::INTERNAL_SERVER_ERROR
-            })?;
+        .load_one(client_info::Entity, conn)
+        .await
+        .map_err(|e| {
+            error!(key.count=audits.len(), err=?e, "Could not look up client info for recent audits");
+            StatusCode::INTERNAL_SERVER_ERROR
+        })?;
 
     let audit_tuples: Vec<AuditTuple> = itertools::izip!(audits, recent_content, client_info)
         .filter_map(|(audit, con, info)| {
@@ -672,6 +672,7 @@ impl Display for Period {
         write!(f, "Last {time_period}")
     }
 }
+
 impl Period {
     fn cutoff_time(&self) -> DateTime<Utc> {
         let duration = match self {
@@ -705,10 +706,7 @@ pub async fn is_content_in_deadzone(
     let builder = state.database_connection.get_database_backend();
     let mut average_radius = Query::select();
     average_radius
-        .expr_as(
-            Expr::col(census_node::Column::DataRadius),
-            Alias::new("data_radius"),
-        )
+        .expr(Expr::col((census_node::Entity, census_node::Column::DataRadius)))
         .expr(Expr::col((node::Entity, node::Column::NodeId)))
         .expr(Expr::col((record::Entity, record::Column::Raw)))
         .from(census_node::Entity)
@@ -717,13 +715,24 @@ pub async fn is_content_in_deadzone(
         .from_subquery(
             Query::select()
                 .from(census::Entity)
-                .expr_as(Expr::max(Expr::col(census::Column::Id)), Alias::new("id"))
+                .expr_as(Expr::col(census::Column::StartedAt), Alias::new("started_at"))
+                .expr_as(Expr::col(census::Column::Duration), Alias::new("duration"))
+                .order_by(census::Column::StartedAt, Order::Desc)
+                .limit(1)
                 .take(),
-            Alias::new("max_census_id"),
+            Alias::new("latest_census"),
         )
         .and_where(
-            Expr::col((census_node::Entity, census_node::Column::CensusId))
-                .eq(Expr::col((Alias::new("max_census_id"), Alias::new("id")))),
+            Expr::col((census_node::Entity, census_node::Column::SurveyedAt))
+                .gte(Expr::col((Alias::new("latest_census"), Alias::new("started_at")))),
+        )
+        .and_where(
+            Expr::col((census_node::Entity, census_node::Column::SurveyedAt))
+                .lt(Expr::cust(if builder == DbBackend::Sqlite {
+                    "STRFTIME('%Y-%m-%dT%H:%M:%S.%f', DATETIME(latest_census.started_at, '+' || latest_census.duration || ' seconds'))"
+                } else {
+                    "latest_census.started_at + latest_census.duration * interval '1 second'"
+                })),
         )
         .and_where(
             Expr::col((census_node::Entity, census_node::Column::RecordId))
@@ -734,20 +743,21 @@ pub async fn is_content_in_deadzone(
                 .eq(Expr::col((node::Entity, node::Column::Id))),
         );
 
-    let dead_zone_data = DeadZoneData::find_by_statement(builder.build(&average_radius))
+    let dead_zone_data_vec = DeadZoneData::find_by_statement(builder.build(&average_radius))
         .all(&state.database_connection)
         .await
         .unwrap();
 
     let content_key: ethportal_api::HistoryContentKey =
         serde_json::from_value(serde_json::json!(content_key)).unwrap();
+    let content_id = content_key.content_id();
 
     let mut enrs: Vec<String> = vec![];
-    for i in dead_zone_data {
-        let radius = Distance::from(crate::U256::from_big_endian(&i.data_radius));
-        let node_id = Distance::from(crate::U256::from_big_endian(&i.node_id));
-        if XorMetric::distance(&content_key.content_id(), &node_id.big_endian()) <= radius {
-            enrs.push(i.raw);
+    for dead_zone_data in dead_zone_data_vec {
+        let radius = Distance::from(crate::U256::from_big_endian(&dead_zone_data.data_radius));
+        let node_id = Distance::from(crate::U256::from_big_endian(&dead_zone_data.node_id));
+        if XorMetric::distance(&content_id, &node_id.big_endian()) <= radius {
+            enrs.push(dead_zone_data.raw);
         }
     }
 

--- a/glados-web/src/routes.rs
+++ b/glados-web/src/routes.rs
@@ -704,8 +704,8 @@ pub async fn is_content_in_deadzone(
     Extension(state): Extension<Arc<State>>,
 ) -> Result<Json<Vec<String>>, StatusCode> {
     let builder = state.database_connection.get_database_backend();
-    let mut average_radius = Query::select();
-    average_radius
+    let mut select_dead_zone_data = Query::select();
+    select_dead_zone_data
         .expr(Expr::col((census_node::Entity, census_node::Column::DataRadius)))
         .expr(Expr::col((node::Entity, node::Column::NodeId)))
         .expr(Expr::col((record::Entity, record::Column::Raw)))
@@ -743,7 +743,7 @@ pub async fn is_content_in_deadzone(
                 .eq(Expr::col((node::Entity, node::Column::Id))),
         );
 
-    let dead_zone_data_vec = DeadZoneData::find_by_statement(builder.build(&average_radius))
+    let dead_zone_data_vec = DeadZoneData::find_by_statement(builder.build(&select_dead_zone_data))
         .all(&state.database_connection)
         .await
         .unwrap();


### PR DESCRIPTION
The SQL which is most of this PR is just copy pasted from @KaydenML draft-PR so I am co-authoring the commit https://github.com/ethereum/glados/pull/176

There has been talks about possible deadzones on our network. But I didn't really think of it much till I ran the bridge in node count 16 mode and tried to gossip a block body 20 times or something. This is when I came to the realization what Mike and I believe Nick mentioned to check... a deadzone. I had an assumption that with the radius's on the network that couldn't be an issue, but after all maybe it could be a deadzone?

So this api checks if any nodes found in the latest census would accept the content_key if they were offered.