### PR TITLE
feat: Adds audit dashboard with filters

### DIFF
--- a/glados-web/src/lib.rs
+++ b/glados-web/src/lib.rs
@@ -77,6 +77,8 @@ pub async fn run_glados_web(config: Arc<State>) -> Result<()> {
             get(routes::contentkey_detail),
         )
         .route("/audit/id/:audit_id", get(routes::contentaudit_detail))
+        .route("/audits/", get(routes::contentaudit_dashboard))
+        .route("/audits/filter/", get(routes::contentaudit_filter))
         .route(
             "/api/hourly-success-rate/",
             get(routes::hourly_success_rate),

--- a/glados-web/src/templates.rs
+++ b/glados-web/src/templates.rs
@@ -57,6 +57,12 @@ pub struct ContentDashboardTemplate {
 }
 
 #[derive(Template)]
+#[template(path = "audit_table.html")]
+pub struct AuditTableTemplate {
+    pub audits: Vec<AuditTuple>,
+}
+
+#[derive(Template)]
 #[template(path = "contentid_list.html")]
 pub struct ContentIdListTemplate {
     pub contentid_list: Vec<content::Model>,
@@ -82,6 +88,10 @@ pub struct ContentAuditDetailTemplate {
 pub struct ContentKeyListTemplate {
     pub contentkey_list: Vec<content::Model>,
 }
+
+#[derive(Template)]
+#[template(path = "audit_dashboard.html")]
+pub struct AuditDashboardTemplate {}
 
 #[derive(Template)]
 #[template(path = "contentkey_detail.html")]

--- a/glados-web/src/templates.rs
+++ b/glados-web/src/templates.rs
@@ -57,12 +57,6 @@ pub struct ContentDashboardTemplate {
 }
 
 #[derive(Template)]
-#[template(path = "audit_table.html")]
-pub struct AuditTableTemplate {
-    pub audits: Vec<AuditTuple>,
-}
-
-#[derive(Template)]
 #[template(path = "contentid_list.html")]
 pub struct ContentIdListTemplate {
     pub contentid_list: Vec<content::Model>,
@@ -92,6 +86,13 @@ pub struct ContentKeyListTemplate {
 #[derive(Template)]
 #[template(path = "audit_dashboard.html")]
 pub struct AuditDashboardTemplate {}
+
+#[derive(Template)]
+#[template(path = "audit_table.html")]
+pub struct AuditTableTemplate {
+    pub stats: [Stats; 3],
+    pub audits: Vec<AuditTuple>,
+}
 
 #[derive(Template)]
 #[template(path = "contentkey_detail.html")]

--- a/glados-web/templates/audit_dashboard.html
+++ b/glados-web/templates/audit_dashboard.html
@@ -1,0 +1,142 @@
+{% extends "base.html" %}
+
+{% block title %}Content Dashboard{% endblock %}
+{% block head %}
+<link href="/static/css/glados_pages.css" rel="stylesheet">
+{% endblock %}
+{% block content %}
+<div class="row">
+    <div class="col">
+        <ul>
+            <br />
+            <h1 class="header">Audit Dashboard</h1>
+            <div id="content-buttons" class="btn-group mr-2" role="group">
+                <button id="all-content-button" filter="All" class="btn btn-outline-secondary" type="button">All
+                </button>
+                <button id="headers-button" filter="Headers" class="btn btn-outline-secondary"
+                    type="button">Headers</button>
+                <button id="bodies-button" filter="Bodies" class="btn btn-outline-secondary"
+                    type="button">Bodies</button>
+                <button id="receipts-button" filter="Receipts" class="btn btn-outline-secondary"
+                    type="button">Receipts</button>
+            </div>
+            <div id="strategy-buttons" class="btn-group">
+                <button id="all-strategy-button" filter="All" class="btn btn-outline-secondary"
+                    type="button">All</button>
+                <button id="latest-button" filter="Latest" class="btn btn-outline-secondary"
+                    type="button">Latest</button>
+                <button id="random-button" filter="Random" class="btn btn-outline-secondary"
+                    type="button">Random</button>
+                <button id="oldest-button" filter="Oldest" class="btn btn-outline-secondary" type="button">Oldest
+                    Unaudited</button>
+            </div>
+            <div id="success-buttons" class="btn-group">
+                <button id="all-success-button" filter="All" class="btn btn-outline-secondary"
+                    type="button">All</button>
+                <button id="success-button" filter="Success" class="btn btn-outline-secondary" type="button">Success
+                </button>
+                <button id="failure-button" filter="Failure" class="btn btn-outline-secondary"
+                    type="button">Failure</button>
+            </div>
+
+        </ul>
+    </div>
+</div>
+<div id="audit-table"></div>
+<style>
+    .btn-outline-secondary.active {
+        background-color: #474747;
+    }
+</style>
+<script>
+
+    $(document).ready(function () {
+
+        const contentGroup = document.querySelector('#content-buttons');
+        const strategyGroup = document.querySelector('#strategy-buttons');
+        const successGroup = document.querySelector('#success-buttons');
+
+        const activateButton = (btn, group) => {
+            // Deactivate all buttons in the group
+            group.querySelectorAll('.btn').forEach(button => {
+                button.classList.remove('active');
+            });
+            // Activate the clicked button
+            btn.classList.add('active');
+        };
+
+        const handleButtonClick = (event, group) => {
+            if (event.target.classList.contains('btn')) {
+                activateButton(event.target, group);
+            }
+
+            // Store the active button in each group in session storage
+            sessionStorage.setItem('content-filter', `#${contentGroup.querySelector('.active').id}`);
+            sessionStorage.setItem('strategy-filter', `#${strategyGroup.querySelector('.active').id}`);
+            sessionStorage.setItem('success-filter', `#${successGroup.querySelector('.active').id}`);
+
+            // Get the active button's filter string in each group
+            const selectedContent = contentGroup.querySelector('.active').getAttribute('filter');
+            const selectedStrategy = strategyGroup.querySelector('.active').getAttribute('filter');
+            const selectedSuccess = successGroup.querySelector('.active').getAttribute('filter');
+
+            updateDashboard(selectedStrategy, selectedContent, selectedSuccess);
+
+        };
+
+        // Check whether the browser's session storage contains a filter for the given group, otherwise use default
+        const setInitialButton = (filter, defaultButton, group) => {
+            if (sessionStorage.getItem(filter) !== null) {
+                activateButton(document.querySelector(`${sessionStorage.getItem(filter)}`), group);
+            } else {
+                activateButton(document.querySelector(defaultButton), group);
+            }
+        }
+
+        // Attach event listeners to each button group
+        contentGroup.addEventListener('click', (event) => handleButtonClick(event, contentGroup));
+        strategyGroup.addEventListener('click', (event) => handleButtonClick(event, strategyGroup));
+        successGroup.addEventListener('click', (event) => handleButtonClick(event, successGroup));
+
+        setInitialButton('content-filter', '#all-content-button', contentGroup);
+        setInitialButton('strategy-filter', '#all-strategy-button', strategyGroup);
+        setInitialButton('success-filter', '#all-success-button', successGroup);
+
+        const selectedContent = contentGroup.querySelector('.active').getAttribute('filter');
+        const selectedStrategy = strategyGroup.querySelector('.active').getAttribute('filter');
+        const selectedSuccess = successGroup.querySelector('.active').getAttribute('filter');
+
+        updateDashboard(selectedStrategy, selectedContent, selectedSuccess);
+
+    });
+
+    function updateDashboard(strategy, content_type, success) {
+
+        const baseUrl = "filter/";
+        const params = {
+            strategy: strategy,
+            content_type: content_type,
+            success: success,
+        };
+
+        const queryString = new URLSearchParams(params).toString();
+
+        fetch(`${baseUrl}?${queryString}`)
+            .then(response => {
+                if (!response.ok) {
+                    throw new Error('Network response was not ok');
+                }
+                return response.text();
+            })
+            .then(data => {
+                document.getElementById('audit-table').innerHTML = data;
+            })
+            .catch(error => {
+                console.log('There was a problem with the fetch operation:', error.message);
+            });
+    }
+
+</script>
+
+
+{% endblock %}

--- a/glados-web/templates/audit_dashboard.html
+++ b/glados-web/templates/audit_dashboard.html
@@ -9,34 +9,36 @@
     <div class="col">
         <ul>
             <br />
-            <h1 class="header">Audit Dashboard</h1>
-            <div id="content-buttons" class="btn-group mr-2" role="group">
-                <button id="all-content-button" filter="All" class="btn btn-outline-secondary" type="button">All
-                </button>
-                <button id="headers-button" filter="Headers" class="btn btn-outline-secondary"
-                    type="button">Headers</button>
-                <button id="bodies-button" filter="Bodies" class="btn btn-outline-secondary"
-                    type="button">Bodies</button>
-                <button id="receipts-button" filter="Receipts" class="btn btn-outline-secondary"
-                    type="button">Receipts</button>
-            </div>
-            <div id="strategy-buttons" class="btn-group">
-                <button id="all-strategy-button" filter="All" class="btn btn-outline-secondary"
-                    type="button">All</button>
-                <button id="latest-button" filter="Latest" class="btn btn-outline-secondary"
-                    type="button">Latest</button>
-                <button id="random-button" filter="Random" class="btn btn-outline-secondary"
-                    type="button">Random</button>
-                <button id="oldest-button" filter="Oldest" class="btn btn-outline-secondary" type="button">Oldest
-                    Unaudited</button>
-            </div>
-            <div id="success-buttons" class="btn-group">
-                <button id="all-success-button" filter="All" class="btn btn-outline-secondary"
-                    type="button">All</button>
-                <button id="success-button" filter="Success" class="btn btn-outline-secondary" type="button">Success
-                </button>
-                <button id="failure-button" filter="Failure" class="btn btn-outline-secondary"
-                    type="button">Failure</button>
+            <h1 class="header text-center">Audit Dashboard</h1>
+            <div class="d-flex justify-content-center flex-wrap">
+                <div id="content-buttons" class="btn-group mx-1" role="group">
+                    <button id="all-content-button" filter="All" class="btn btn-outline-secondary"
+                        type="button">All</button>
+                    <button id="headers-button" filter="Headers" class="btn btn-outline-secondary"
+                        type="button">Headers</button>
+                    <button id="bodies-button" filter="Bodies" class="btn btn-outline-secondary"
+                        type="button">Bodies</button>
+                    <button id="receipts-button" filter="Receipts" class="btn btn-outline-secondary"
+                        type="button">Receipts</button>
+                </div>
+                <div id="strategy-buttons" class="btn-group mx-1" role="group">
+                    <button id="all-strategy-button" filter="All" class="btn btn-outline-secondary"
+                        type="button">All</button>
+                    <button id="latest-button" filter="Latest" class="btn btn-outline-secondary"
+                        type="button">Latest</button>
+                    <button id="random-button" filter="Random" class="btn btn-outline-secondary"
+                        type="button">Random</button>
+                    <button id="oldest-button" filter="Oldest" class="btn btn-outline-secondary" type="button">Oldest
+                        Unaudited</button>
+                </div>
+                <div id="success-buttons" class="btn-group mx-1 " role="group">
+                    <button id="all-success-button" filter="All" class="btn btn-outline-secondary"
+                        type="button">All</button>
+                    <button id="success-button" filter="Success" class="btn btn-outline-secondary"
+                        type="button">Success</button>
+                    <button id="failure-button" filter="Failure" class="btn btn-outline-secondary"
+                        type="button">Failure</button>
+                </div>
             </div>
 
         </ul>

--- a/glados-web/templates/audit_table.html
+++ b/glados-web/templates/audit_table.html
@@ -1,50 +1,84 @@
-<div class="row">
-    <div class="col">
-        <ul>
-            <div class="card shadow-sm content-card">
-                <div class="card-body">
-                    <table class="table">
-                        <thead>
-                            <tr>
-                                <th scope="col">Audit</th>
-                                <th scope="col">Result</th>
-                                <th scope="col">Sub-protocol</th>
-                                <th scope="col">Strategy</th>
-                                <th scope="col">Content Key</th>
-                                <th scope="col">Content ID</th>
-                                <th scope="col">Content first available</th>
-                                <th scope="col">Audited at</th>
-                                <th scope="col">Client</th>
-                            </tr>
-                        </thead>
-                        <tbody>
-                            {% for (audit, content, client_info) in audits %}
-                            <tr>
-                                <td>{% if audit.trace != "" %}<a href="/audit/id/{{ audit.id }}">{{ audit.id }}</a>{%
-                                    else
-                                    %}
-                                    {{ audit.id }}{% endif %}
-                                </td>
-                                <td><span
-                                        class="badge text-bg-{% if audit.is_success() %}success{% else %}danger{% endif %}">{%
-                                        if audit.is_success() %}Success{% else %}Fail{% endif %}</span></td>
-                                <td>{{ content.protocol_id.as_text() }}</td>
-                                <td>{{ audit.strategy_as_text() }}</td>
-                                <td><a href="/content/key/{{content.key_as_hex()}}/">{{ content.key_as_hex_short()
-                                        }}</a>
-                                </td>
-                                <td><a href="/content/id/{{content.id_as_hex()}}/">{{ content.id_as_hex_short() }}</a>
-                                </td>
-                                <td title="{{ content.available_at_local_time() }}">{{ content.available_at_humanized()
-                                    }}</td>
-                                <td title="{{ audit.created_at_local_time() }}">{{ audit.created_at_humanized() }}</td>
-                                <td>{{ client_info.version_info }}</td>
-                            </tr>
-                            {% endfor %}
-                        </tbody>
-                    </table>
+<div class="container">
+    <div class="card shadow-sm content-card bx-2 mb-3">
+        <table class="table">
+            <thead>
+                <tr>
+                    <th scope="col">Period</th>
+                    <th scope="col">Total audits</th>
+                    <th scope="col">Total audit passes</th>
+                    <th scope="col">Total audit failures</th>
+                    <th scope="col"><span class="badge text-bg-success">Pass rate</span> (%)</th>
+                    <th scope="col"><span class="badge text-bg-danger">Failure rate</span> (%)</th>
+                    <th scope="col">Audits per minute</th>
+                </tr>
+            </thead>
+            <tbody>
+                {% for stat in stats %}
+                <tr>
+                    <th scope="row">{{ stat.period.to_string() }}</th>
+                    <td>{{ stat.total_audits }}</td>
+                    <td>{{ stat.total_passes }}</td>
+                    <td>{{ stat.total_failures }}</td>
+                    <td>{{ "{:.1}"|format(stat.pass_percent) }}%</td>
+                    <td>{{ "{:.1}"|format(stat.fail_percent) }}%</td>
+                    <td>{{ stat.audits_per_minute }}</td>
+                </tr>
+                {% endfor %}
+            </tbody>
+        </table>
+    </div>
+    <div class="row">
+        <div class="col">
+            <ul class="list-unstyled">
+                <div class="card shadow-sm content-card">
+                    <div class="card-body">
+                        <table class="table">
+                            <thead>
+                                <tr>
+                                    <th scope="col">Audit</th>
+                                    <th scope="col">Result</th>
+                                    <th scope="col">Sub-protocol</th>
+                                    <th scope="col">Strategy</th>
+                                    <th scope="col">Content Key</th>
+                                    <th scope="col">Content ID</th>
+                                    <th scope="col">Content first available</th>
+                                    <th scope="col">Audited at</th>
+                                    <th scope="col">Client</th>
+                                </tr>
+                            </thead>
+                            <tbody>
+                                {% for (audit, content, client_info) in audits %}
+                                <tr>
+                                    <td>{% if audit.trace != "" %}<a href="/audit/id/{{ audit.id }}">{{ audit.id
+                                            }}</a>{%
+                                        else
+                                        %}
+                                        {{ audit.id }}{% endif %}
+                                    </td>
+                                    <td><span
+                                            class="badge text-bg-{% if audit.is_success() %}success{% else %}danger{% endif %}">{%
+                                            if audit.is_success() %}Success{% else %}Fail{% endif %}</span></td>
+                                    <td>{{ content.protocol_id.as_text() }}</td>
+                                    <td>{{ audit.strategy_as_text() }}</td>
+                                    <td><a href="/content/key/{{content.key_as_hex()}}/">{{ content.key_as_hex_short()
+                                            }}</a>
+                                    </td>
+                                    <td><a href="/content/id/{{content.id_as_hex()}}/">{{ content.id_as_hex_short()
+                                            }}</a>
+                                    </td>
+                                    <td title="{{ content.available_at_local_time() }}">{{
+                                        content.available_at_humanized()
+                                        }}</td>
+                                    <td title="{{ audit.created_at_local_time() }}">{{ audit.created_at_humanized() }}
+                                    </td>
+                                    <td>{{ client_info.version_info }}</td>
+                                </tr>
+                                {% endfor %}
+                            </tbody>
+                        </table>
+                    </div>
                 </div>
-            </div>
-        </ul>
+            </ul>
+        </div>
     </div>
 </div>

--- a/glados-web/templates/audit_table.html
+++ b/glados-web/templates/audit_table.html
@@ -1,0 +1,50 @@
+<div class="row">
+    <div class="col">
+        <ul>
+            <div class="card shadow-sm content-card">
+                <div class="card-body">
+                    <table class="table">
+                        <thead>
+                            <tr>
+                                <th scope="col">Audit</th>
+                                <th scope="col">Result</th>
+                                <th scope="col">Sub-protocol</th>
+                                <th scope="col">Strategy</th>
+                                <th scope="col">Content Key</th>
+                                <th scope="col">Content ID</th>
+                                <th scope="col">Content first available</th>
+                                <th scope="col">Audited at</th>
+                                <th scope="col">Client</th>
+                            </tr>
+                        </thead>
+                        <tbody>
+                            {% for (audit, content, client_info) in audits %}
+                            <tr>
+                                <td>{% if audit.trace != "" %}<a href="/audit/id/{{ audit.id }}">{{ audit.id }}</a>{%
+                                    else
+                                    %}
+                                    {{ audit.id }}{% endif %}
+                                </td>
+                                <td><span
+                                        class="badge text-bg-{% if audit.is_success() %}success{% else %}danger{% endif %}">{%
+                                        if audit.is_success() %}Success{% else %}Fail{% endif %}</span></td>
+                                <td>{{ content.protocol_id.as_text() }}</td>
+                                <td>{{ audit.strategy_as_text() }}</td>
+                                <td><a href="/content/key/{{content.key_as_hex()}}/">{{ content.key_as_hex_short()
+                                        }}</a>
+                                </td>
+                                <td><a href="/content/id/{{content.id_as_hex()}}/">{{ content.id_as_hex_short() }}</a>
+                                </td>
+                                <td title="{{ content.available_at_local_time() }}">{{ content.available_at_humanized()
+                                    }}</td>
+                                <td title="{{ audit.created_at_local_time() }}">{{ audit.created_at_humanized() }}</td>
+                                <td>{{ client_info.version_info }}</td>
+                            </tr>
+                            {% endfor %}
+                        </tbody>
+                    </table>
+                </div>
+            </div>
+        </ul>
+    </div>
+</div>

--- a/glados-web/templates/base.html
+++ b/glados-web/templates/base.html
@@ -18,17 +18,25 @@
 
     <nav class="navbar navbar-expand-lg navbar-light" style="background-color: #ffffff;">
         <div>
-            <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#navbarSupportedContent" aria-controls="navbarSupportedContent" aria-expanded="false" aria-label="Toggle navigation">
+            <button class="navbar-toggler" type="button" data-bs-toggle="collapse"
+                data-bs-target="#navbarSupportedContent" aria-controls="navbarSupportedContent" aria-expanded="false"
+                aria-label="Toggle navigation">
                 <span class="navbar-toggler-icon"></span>
             </button>
             <div class="collapse navbar-collapse" id="navbarSupportedContent">
                 <ul class="navbar-nav me-auto">
                     <a class="nav-link active" style="margin-left: 20px;" href="/">Glados</a>
                     <li class="nav-item">
-                        <a class="nav-link active" aria-current="page" style="margin-left: 20px;" href="/content/">Content Dashboard</a>
+                        <a class="nav-link active" aria-current="page" style="margin-left: 20px;" href="/audits/">Audit
+                            Dashboard</a>
                     </li>
                     <li class="nav-item">
-                        <a class="nav-link active" aria-current="page" style="margin-left: 20px;" href="/network/">Network Explorer</a>
+                        <a class="nav-link active" aria-current="page" style="margin-left: 20px;"
+                            href="/content/">Content Dashboard</a>
+                    </li>
+                    <li class="nav-item">
+                        <a class="nav-link active" aria-current="page" style="margin-left: 20px;"
+                            href="/network/">Network Explorer</a>
                     </li>
                 </ul>
             </div>

--- a/glados-web/templates/index.html
+++ b/glados-web/templates/index.html
@@ -7,6 +7,7 @@
 <script src="https://d3js.org/d3.v7.min.js"></script>
 <script src="/static/js/piechart.js"></script>
 <script src="/static/js/radiusdensity.js"></script>
+<link href="/static/css/homepage.css" rel="stylesheet">
 {% endblock %}
 
 {% block content %}
@@ -19,30 +20,30 @@
                     <h2>Audit stats</h2>
                     <table class="table">
                         <thead>
-                        <tr>
-                            <th scope="col">Period</th>
-                            <th scope="col">New content</th>
-                            <th scope="col">Total audits</th>
-                            <th scope="col">Total audit passes</th>
-                            <th scope="col">Total audit failures</th>
-                            <th scope="col"><span class="badge text-bg-success">Pass rate</span> (%)</th>
-                            <th scope="col"><span class="badge text-bg-danger">Failure rate</span> (%)</th>
-                            <th scope="col">Audits per minute</th>
-                        </tr>
+                            <tr>
+                                <th scope="col">Period</th>
+                                <th scope="col">New content</th>
+                                <th scope="col">Total audits</th>
+                                <th scope="col">Total audit passes</th>
+                                <th scope="col">Total audit failures</th>
+                                <th scope="col"><span class="badge text-bg-success">Pass rate</span> (%)</th>
+                                <th scope="col"><span class="badge text-bg-danger">Failure rate</span> (%)</th>
+                                <th scope="col">Audits per minute</th>
+                            </tr>
                         </thead>
                         <tbody>
-                        {% for stat in stats %}
-                        <tr>
-                            <th scope="row">{{ stat.period.to_string() }}</th>
-                            <td>{{ stat.new_content }}</td>
-                            <td>{{ stat.total_audits }}</td>
-                            <td>{{ stat.total_passes }}</td>
-                            <td>{{ stat.total_failures }}</td>
-                            <td>{{ "{:.1}"|format(stat.pass_percent) }}%</td>
-                            <td>{{ "{:.1}"|format(stat.fail_percent) }}%</td>
-                            <td>{{ stat.audits_per_minute }}</td>
-                        </tr>
-                        {% endfor %}
+                            {% for stat in stats %}
+                            <tr>
+                                <th scope="row">{{ stat.period.to_string() }}</th>
+                                <td>{{ stat.new_content }}</td>
+                                <td>{{ stat.total_audits }}</td>
+                                <td>{{ stat.total_passes }}</td>
+                                <td>{{ stat.total_failures }}</td>
+                                <td>{{ "{:.1}"|format(stat.pass_percent) }}%</td>
+                                <td>{{ "{:.1}"|format(stat.fail_percent) }}%</td>
+                                <td>{{ stat.audits_per_minute }}</td>
+                            </tr>
+                            {% endfor %}
                         </tbody>
                     </table>
                 </div>
@@ -66,13 +67,13 @@
             <div id="census-scatterplot"></div>
         </div>
     </div>
-    <div id="hover" style="pointer-events: none; position: absolute; opacity: 0;" ></div>
+    <div id="hover" style="pointer-events: none; position: absolute; opacity: 0;"></div>
 </div>
 
 <script>
 
-    pie_chart_count({{ pie_chart_client_count|json|safe }})
-    radius_node_id_scatter_chart({{ average_radius_chart|json|safe }})
+    pie_chart_count({{ pie_chart_client_count| json | safe }})
+    radius_node_id_scatter_chart({{ average_radius_chart| json | safe }})
 
 </script>
 


### PR DESCRIPTION
This pr adds audit dashboard, which is similar to the current content dashboard except that it shows one pane of audits and allows them and their hour/day/week stats to be filtered by any combination of strategy, content type, and success. 

Similar idea as #156, except that only the data required is fetched from the server via an `/audits/filter/` endpoint, rather than all of the data being loaded and most of it being hidden.

closes #158 and #182