### PR TITLE
fix: uses .dockerignore to skip copying target folder

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,3 @@
+target
+.git
+


### PR DESCRIPTION
Docker builds were taking a long time because the entire target directory was being copied to the builder, which is unnecessary because we're building from source on the builder.