### PR TITLE
feat: adds audit stats recording and historical display

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1444,13 +1444,13 @@ dependencies = [
  "env_logger 0.10.0",
  "ethereum-types 0.14.1",
  "ethportal-api",
- "glados-core",
  "migration",
  "primitive-types 0.10.1",
  "rand 0.8.5",
  "rstest 0.16.0",
  "sea-orm",
  "sea-query",
+ "serde",
  "tokio",
 ]
 
@@ -2131,7 +2131,9 @@ name = "glados-core"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "chrono",
  "discv5 0.1.0",
+ "entity",
  "env_logger 0.9.3",
  "ethereum-types 0.14.1",
  "ethportal-api",
@@ -2140,6 +2142,7 @@ dependencies = [
  "reth-ipc",
  "rstest 0.11.0",
  "rustc-hex",
+ "sea-orm",
  "serde",
  "serde_json",
  "sha2 0.10.7",

--- a/entity/Cargo.toml
+++ b/entity/Cargo.toml
@@ -15,7 +15,6 @@ clap = { version = "4.0.24", features = ["derive"] }
 enr = "0.8.1"
 ethereum-types = "0.14.0"
 ethportal-api = "0.2.2"
-glados-core = { path = "../glados-core" }
 migration = { path = "../migration" }
 sea-orm = { version = "0.11.3", features = ["sqlx-postgres", "sqlx-sqlite", "macros", "runtime-tokio-native-tls"] }
 sea-query = "0.28.4"
@@ -23,6 +22,7 @@ tokio = { version = "1.21.2", features = ["macros"] }
 env_logger = "0.10.0"
 rand = "0.8.5"
 rstest = "0.16.0"
+serde = "1.0.167"
 primitive-types = "0.10.1"
 
 

--- a/entity/src/audit_stats.rs
+++ b/entity/src/audit_stats.rs
@@ -1,0 +1,84 @@
+use chrono::Duration;
+
+use anyhow::Result;
+use chrono::{DateTime, Utc};
+use sea_orm::{entity::prelude::*, ActiveValue::NotSet, QueryOrder, Set};
+use serde::Serialize;
+
+#[derive(Clone, Debug, DeriveEntityModel, Serialize)]
+#[sea_orm(table_name = "audit_stats")]
+pub struct Model {
+    #[sea_orm(primary_key)]
+    pub id: i32,
+    pub timestamp: DateTime<Utc>,
+    pub num_audits: i32,
+    pub success_rate_all: f32,
+    pub success_rate_latest: f32,
+    pub success_rate_random: f32,
+    pub success_rate_oldest: f32,
+    pub success_rate_all_headers: f32,
+    pub success_rate_all_bodies: f32,
+    pub success_rate_all_receipts: f32,
+    pub success_rate_latest_headers: f32,
+    pub success_rate_latest_bodies: f32,
+    pub success_rate_latest_receipts: f32,
+    pub success_rate_random_headers: f32,
+    pub success_rate_random_bodies: f32,
+    pub success_rate_random_receipts: f32,
+}
+
+#[derive(Copy, Clone, Debug, EnumIter, DeriveRelation)]
+pub enum Relation {}
+
+impl ActiveModelBehavior for ActiveModel {}
+
+#[allow(clippy::too_many_arguments)]
+pub async fn create(
+    timestamp: DateTime<Utc>,
+    num_audits: i32,
+    success_rate_all: f32,
+    success_rate_latest: f32,
+    success_rate_random: f32,
+    success_rate_oldest: f32,
+    success_rate_all_headers: f32,
+    success_rate_all_bodies: f32,
+    success_rate_all_receipts: f32,
+    success_rate_latest_headers: f32,
+    success_rate_latest_bodies: f32,
+    success_rate_latest_receipts: f32,
+    success_rate_random_headers: f32,
+    success_rate_random_bodies: f32,
+    success_rate_random_receipts: f32,
+    conn: &DatabaseConnection,
+) -> Result<Model> {
+    let audit_stats = ActiveModel {
+        id: NotSet,
+        timestamp: Set(timestamp),
+        num_audits: Set(num_audits),
+        success_rate_all: Set(success_rate_all),
+        success_rate_latest: Set(success_rate_latest),
+        success_rate_random: Set(success_rate_random),
+        success_rate_oldest: Set(success_rate_oldest),
+        success_rate_all_headers: Set(success_rate_all_headers),
+        success_rate_all_bodies: Set(success_rate_all_bodies),
+        success_rate_all_receipts: Set(success_rate_all_receipts),
+        success_rate_latest_headers: Set(success_rate_latest_headers),
+        success_rate_latest_bodies: Set(success_rate_latest_bodies),
+        success_rate_latest_receipts: Set(success_rate_latest_receipts),
+        success_rate_random_headers: Set(success_rate_random_headers),
+        success_rate_random_bodies: Set(success_rate_random_bodies),
+        success_rate_random_receipts: Set(success_rate_random_receipts),
+    };
+    Ok(audit_stats.insert(conn).await?)
+}
+
+/// Get the most recent audit stat series of the last 7 days.
+pub async fn get_recent_stats(conn: &DatabaseConnection) -> Result<Vec<Model>, DbErr> {
+    let one_week_ago = Utc::now() - Duration::days(7);
+
+    Entity::find()
+        .filter(Column::Timestamp.gt(one_week_ago))
+        .order_by_asc(Column::Timestamp)
+        .all(conn)
+        .await
+}

--- a/entity/src/lib.rs
+++ b/entity/src/lib.rs
@@ -2,6 +2,7 @@
 
 pub mod prelude;
 
+pub mod audit_stats;
 pub mod census;
 pub mod census_node;
 pub mod client_info;

--- a/glados-audit/src/cli.rs
+++ b/glados-audit/src/cli.rs
@@ -2,6 +2,7 @@ use clap::{ArgAction, Parser, Subcommand, ValueEnum};
 use entity::content_audit::SelectionStrategy;
 
 const DEFAULT_DB_URL: &str = "sqlite::memory:";
+const DEFAULT_STATS_PERIOD: &str = "300";
 
 #[derive(Parser, Debug, Eq, PartialEq)]
 #[command(author, version, about, long_about = None)]
@@ -40,6 +41,8 @@ pub struct Args {
         help = "relative weight of the 'random' strategy"
     )]
     pub random_strategy_weight: u8,
+    #[arg(long, default_value = DEFAULT_STATS_PERIOD, help = "stats recording period (seconds)")]
+    pub stats_recording_period: u64,
     #[arg(short, long, action(ArgAction::Append))]
     pub portal_client: Vec<String>,
     #[command(subcommand)]
@@ -68,6 +71,7 @@ impl Default for Args {
             strategy: None,
             portal_client: vec!["ipc:////tmp/trin-jsonrpc.ipc".to_owned()],
             subcommand: None,
+            stats_recording_period: 300,
         }
     }
 }

--- a/glados-audit/src/lib.rs
+++ b/glados-audit/src/lib.rs
@@ -29,6 +29,7 @@ use crate::{selection::start_audit_selection_task, validation::content_is_valid}
 
 pub mod cli;
 pub(crate) mod selection;
+pub mod stats;
 pub(crate) mod validation;
 
 /// Configuration created from CLI arguments.
@@ -44,6 +45,8 @@ pub struct AuditConfig {
     pub concurrency: u8,
     /// Portal Clients
     pub portal_clients: Vec<PortalClient>,
+    /// Number of seconds between recording the current audit performance in audit_stats table.
+    pub stats_recording_period: u64,
 }
 
 impl AuditConfig {
@@ -97,6 +100,7 @@ impl AuditConfig {
             weights,
             concurrency: args.concurrency,
             portal_clients,
+            stats_recording_period: args.stats_recording_period,
         })
     }
 }

--- a/glados-audit/src/main.rs
+++ b/glados-audit/src/main.rs
@@ -1,6 +1,8 @@
 use anyhow::Result;
 use clap::Parser;
+use glados_audit::stats::periodically_record_stats;
 use sea_orm::Database;
+use tokio::time::Duration;
 use tracing::{debug, info};
 
 use glados_audit::cli::{Args, Command};
@@ -62,6 +64,10 @@ async fn run_audit(args: Args) -> Result<()> {
     );
 
     Migrator::up(&conn, None).await?;
+    tokio::spawn(periodically_record_stats(
+        Duration::from_secs(config.stats_recording_period),
+        conn.clone(),
+    ));
     run_glados_audit(conn, config).await;
     Ok(())
 }

--- a/glados-audit/src/stats.rs
+++ b/glados-audit/src/stats.rs
@@ -1,0 +1,203 @@
+use chrono::Utc;
+use entity::audit_stats;
+use glados_core::stats::{
+    filter_audits, get_audit_stats, AuditFilters, ContentTypeFilter, Period, StrategyFilter,
+    SuccessFilter,
+};
+use sea_orm::{DatabaseConnection, DbErr};
+use tokio::time::{interval, Duration};
+use tracing::{debug, error, info};
+
+/// Loops indefinitely, periodically recording audit stats to the database.
+pub async fn periodically_record_stats(period: Duration, conn: DatabaseConnection) -> ! {
+    debug!("initializing task for logging audit stats");
+    let mut interval = interval(period);
+
+    loop {
+        record_current_stats(&conn).await.unwrap_or_else(|e| {
+            error!("failed to record audit stats: {e}");
+        });
+        info!("Successfully recorded audit stats");
+        interval.tick().await;
+    }
+}
+
+/// Records audit stats for the current moment to the database.
+/// Calculates success rate for many combinations of strategy and content type.
+async fn record_current_stats(conn: &DatabaseConnection) -> Result<(), DbErr> {
+    // Run audit stat queries in parallel.
+    let (
+        all,
+        latest,
+        random,
+        oldest,
+        all_headers,
+        all_bodies,
+        all_receipts,
+        latest_headers,
+        latest_bodies,
+        latest_receipts,
+        random_headers,
+        random_bodies,
+        random_receipts,
+    ) = tokio::join!(
+        get_audit_stats(
+            filter_audits(AuditFilters {
+                strategy: StrategyFilter::All,
+                content_type: ContentTypeFilter::All,
+                success: SuccessFilter::All
+            }),
+            Period::Hour,
+            conn
+        ),
+        get_audit_stats(
+            filter_audits(AuditFilters {
+                strategy: StrategyFilter::Latest,
+                content_type: ContentTypeFilter::All,
+                success: SuccessFilter::All
+            }),
+            Period::Hour,
+            conn
+        ),
+        get_audit_stats(
+            filter_audits(AuditFilters {
+                strategy: StrategyFilter::Random,
+                content_type: ContentTypeFilter::All,
+                success: SuccessFilter::All
+            }),
+            Period::Hour,
+            conn
+        ),
+        get_audit_stats(
+            filter_audits(AuditFilters {
+                strategy: StrategyFilter::Oldest,
+                content_type: ContentTypeFilter::All,
+                success: SuccessFilter::All
+            }),
+            Period::Hour,
+            conn
+        ),
+        get_audit_stats(
+            filter_audits(AuditFilters {
+                strategy: StrategyFilter::All,
+                content_type: ContentTypeFilter::Headers,
+                success: SuccessFilter::All
+            }),
+            Period::Hour,
+            conn
+        ),
+        get_audit_stats(
+            filter_audits(AuditFilters {
+                strategy: StrategyFilter::All,
+                content_type: ContentTypeFilter::Bodies,
+                success: SuccessFilter::All
+            }),
+            Period::Hour,
+            conn
+        ),
+        get_audit_stats(
+            filter_audits(AuditFilters {
+                strategy: StrategyFilter::All,
+                content_type: ContentTypeFilter::Receipts,
+                success: SuccessFilter::All
+            }),
+            Period::Hour,
+            conn
+        ),
+        get_audit_stats(
+            filter_audits(AuditFilters {
+                strategy: StrategyFilter::Latest,
+                content_type: ContentTypeFilter::Headers,
+                success: SuccessFilter::All
+            }),
+            Period::Hour,
+            conn
+        ),
+        get_audit_stats(
+            filter_audits(AuditFilters {
+                strategy: StrategyFilter::Latest,
+                content_type: ContentTypeFilter::Bodies,
+                success: SuccessFilter::All
+            }),
+            Period::Hour,
+            conn
+        ),
+        get_audit_stats(
+            filter_audits(AuditFilters {
+                strategy: StrategyFilter::Latest,
+                content_type: ContentTypeFilter::Receipts,
+                success: SuccessFilter::All
+            }),
+            Period::Hour,
+            conn
+        ),
+        get_audit_stats(
+            filter_audits(AuditFilters {
+                strategy: StrategyFilter::Random,
+                content_type: ContentTypeFilter::Headers,
+                success: SuccessFilter::All
+            }),
+            Period::Hour,
+            conn
+        ),
+        get_audit_stats(
+            filter_audits(AuditFilters {
+                strategy: StrategyFilter::Random,
+                content_type: ContentTypeFilter::Bodies,
+                success: SuccessFilter::All
+            }),
+            Period::Hour,
+            conn
+        ),
+        get_audit_stats(
+            filter_audits(AuditFilters {
+                strategy: StrategyFilter::Random,
+                content_type: ContentTypeFilter::Receipts,
+                success: SuccessFilter::All
+            }),
+            Period::Hour,
+            conn
+        )
+    );
+
+    // Handle errors and get success rates.
+    let success_rate_all = all?.pass_percent;
+    let success_rate_latest = latest?.pass_percent;
+    let success_rate_random = random?.pass_percent;
+    let success_rate_oldest = oldest?.pass_percent;
+    let success_rate_all_headers = all_headers?.pass_percent;
+    let success_rate_all_bodies = all_bodies?.pass_percent;
+    let success_rate_all_receipts = all_receipts?.pass_percent;
+    let success_rate_latest_headers = latest_headers?.pass_percent;
+    let success_rate_latest_bodies = latest_bodies?.pass_percent;
+    let success_rate_latest_receipts = latest_receipts?.pass_percent;
+    let success_rate_random_headers = random_headers?.pass_percent;
+    let success_rate_random_bodies = random_bodies?.pass_percent;
+    let success_rate_random_receipts = random_receipts?.pass_percent;
+
+    // Record the values.
+    match audit_stats::create(
+        Utc::now(),
+        0,
+        success_rate_all,
+        success_rate_latest,
+        success_rate_random,
+        success_rate_oldest,
+        success_rate_all_headers,
+        success_rate_all_bodies,
+        success_rate_all_receipts,
+        success_rate_latest_headers,
+        success_rate_latest_bodies,
+        success_rate_latest_receipts,
+        success_rate_random_headers,
+        success_rate_random_bodies,
+        success_rate_random_receipts,
+        conn,
+    )
+    .await
+    {
+        Ok(_) => debug!("successfully recorded audit stats"),
+        Err(e) => error!("failed to record audit stats: {e}",),
+    };
+    Ok(())
+}

--- a/glados-core/Cargo.toml
+++ b/glados-core/Cargo.toml
@@ -12,7 +12,10 @@ authors = ["Piper Merriam <piper@pipermerriam.com>"]
 anyhow = "1.0.68"
 discv5 = "0.1.0"
 ethereum-types = "0.14.0"
+chrono = "0.4.22"
 jsonrpc = "0.13.0"
+entity = { path = "../entity" }
+sea-orm = "0.11.3"
 serde = "1.0.147"
 serde_json = "1.0.87"
 sha2 = "0.10.6"

--- a/glados-core/src/lib.rs
+++ b/glados-core/src/lib.rs
@@ -1,1 +1,2 @@
 pub mod jsonrpc;
+pub mod stats;

--- a/glados-core/src/stats.rs
+++ b/glados-core/src/stats.rs
@@ -1,0 +1,218 @@
+use std::fmt::Display;
+
+use chrono::{DateTime, Duration, Utc};
+
+use entity::{
+    content::{self, SubProtocol},
+    content_audit::{self, AuditResult, SelectionStrategy},
+};
+use sea_orm::{
+    sea_query::{Expr, IntoCondition},
+    ColumnTrait, DatabaseConnection, DbErr, EntityTrait, JoinType, PaginatorTrait, QueryFilter,
+    QuerySelect, RelationTrait, Select,
+};
+use serde::Deserialize;
+
+/// Generates a SeaORM select query for audits based on the provided filters.
+/// User can decide whether to retrieve or only count results.
+/// TODO: add support for filtering by portal client
+pub fn filter_audits(filters: AuditFilters) -> Select<content_audit::Entity> {
+    // This base query will have filters added to it
+    let audits = content_audit::Entity::find();
+    // Strategy filters
+    let audits = match filters.strategy {
+        StrategyFilter::All => audits,
+        StrategyFilter::Random => {
+            audits.filter(content_audit::Column::StrategyUsed.eq(SelectionStrategy::Random))
+        }
+        StrategyFilter::Latest => {
+            audits.filter(content_audit::Column::StrategyUsed.eq(SelectionStrategy::Latest))
+        }
+        StrategyFilter::Oldest => audits.filter(
+            content_audit::Column::StrategyUsed.eq(SelectionStrategy::SelectOldestUnaudited),
+        ),
+    };
+    // Success filters
+    let audits = match filters.success {
+        SuccessFilter::All => audits,
+        SuccessFilter::Success => {
+            audits.filter(content_audit::Column::Result.eq(AuditResult::Success))
+        }
+        SuccessFilter::Failure => {
+            audits.filter(content_audit::Column::Result.eq(AuditResult::Failure))
+        }
+    };
+    // Content type filters
+    match filters.content_type {
+        ContentTypeFilter::All => audits,
+        ContentTypeFilter::Headers => audits.join(
+            JoinType::InnerJoin,
+            content_audit::Relation::Content
+                .def()
+                .on_condition(|_left, right| {
+                    Expr::cust("get_byte(content.content_key, 0) = 0x00")
+                        .and(
+                            Expr::col((right, content::Column::ProtocolId))
+                                .eq(SubProtocol::History),
+                        )
+                        .into_condition()
+                }),
+        ),
+        ContentTypeFilter::Bodies => audits.join(
+            JoinType::InnerJoin,
+            content_audit::Relation::Content
+                .def()
+                .on_condition(|_left, right| {
+                    Expr::cust("get_byte(content.content_key, 0) = 0x01")
+                        .and(
+                            Expr::col((right, content::Column::ProtocolId))
+                                .eq(SubProtocol::History),
+                        )
+                        .into_condition()
+                }),
+        ),
+        ContentTypeFilter::Receipts => audits.join(
+            JoinType::InnerJoin,
+            content_audit::Relation::Content
+                .def()
+                .on_condition(|_left, right| {
+                    Expr::cust("get_byte(content.content_key, 0) = 0x02")
+                        .and(
+                            Expr::col((right, content::Column::ProtocolId))
+                                .eq(SubProtocol::History),
+                        )
+                        .into_condition()
+                }),
+        ),
+    }
+}
+
+/// Calculates stats for the given set of audits over the given period.
+pub async fn get_audit_stats(
+    filtered: Select<content_audit::Entity>,
+    period: Period,
+    conn: &DatabaseConnection,
+) -> Result<AuditStats, DbErr> {
+    let cutoff = period.cutoff_time();
+
+    let new_content = content::Entity::find()
+        .filter(content::Column::FirstAvailableAt.gt(cutoff))
+        .count(conn)
+        .await? as u32;
+
+    let total_audits = filtered
+        .clone()
+        .filter(content_audit::Column::CreatedAt.gt(cutoff))
+        .count(conn)
+        .await? as u32;
+
+    let total_passes = filtered
+        .filter(content_audit::Column::CreatedAt.gt(cutoff))
+        .filter(content_audit::Column::Result.eq(AuditResult::Success))
+        .count(conn)
+        .await? as u32;
+
+    let total_failures = total_audits - total_passes;
+
+    let audits_per_minute = (60 * total_audits)
+        .checked_div(period.total_seconds())
+        .unwrap_or(0);
+
+    let (pass_percent, fail_percent) = if total_audits == 0 {
+        (0.0, 0.0)
+    } else {
+        let total_audits = total_audits as f32;
+        (
+            (total_passes as f32) * 100.0 / total_audits,
+            (total_failures as f32) * 100.0 / total_audits,
+        )
+    };
+
+    Ok(AuditStats {
+        period,
+        new_content,
+        total_audits,
+        total_passes,
+        pass_percent,
+        total_failures,
+        fail_percent,
+        audits_per_minute,
+    })
+}
+
+pub struct AuditStats {
+    pub period: Period,
+    pub new_content: u32,
+    pub total_audits: u32,
+    pub total_passes: u32,
+    pub pass_percent: f32,
+    pub total_failures: u32,
+    pub fail_percent: f32,
+    pub audits_per_minute: u32,
+}
+
+pub enum Period {
+    Hour,
+    Day,
+    Week,
+}
+
+impl Display for Period {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let time_period = match self {
+            Period::Hour => "hour",
+            Period::Day => "day",
+            Period::Week => "week",
+        };
+        write!(f, "Last {time_period}")
+    }
+}
+
+impl Period {
+    fn cutoff_time(&self) -> DateTime<Utc> {
+        let duration = match self {
+            Period::Hour => Duration::hours(1),
+            Period::Day => Duration::days(1),
+            Period::Week => Duration::weeks(1),
+        };
+        Utc::now() - duration
+    }
+
+    fn total_seconds(&self) -> u32 {
+        match self {
+            Period::Hour => 3600,
+            Period::Day => 86400,
+            Period::Week => 604800,
+        }
+    }
+}
+
+#[derive(Deserialize)]
+pub struct AuditFilters {
+    pub strategy: StrategyFilter,
+    pub content_type: ContentTypeFilter,
+    pub success: SuccessFilter,
+}
+
+#[derive(Deserialize)]
+pub enum StrategyFilter {
+    All,
+    Random,
+    Latest,
+    Oldest,
+}
+
+#[derive(Deserialize)]
+pub enum SuccessFilter {
+    All,
+    Success,
+    Failure,
+}
+
+#[derive(Deserialize)]
+pub enum ContentTypeFilter {
+    All,
+    Headers,
+    Bodies,
+    Receipts,
+}

--- a/glados-web/assets/js/stats_history.js
+++ b/glados-web/assets/js/stats_history.js
@@ -1,0 +1,185 @@
+function createMultiLineChart(height, width, dataSets) {
+    // Declare the chart dimensions and margins.
+    const marginTop = 20;
+    const marginRight = 50;
+    const marginBottom = 20;
+    const marginLeft = 40;
+
+    // Parse dates if they're not already Date objects
+    dataSets.forEach(dataset => {
+        dataset.forEach(d => {
+            if (!(d.date instanceof Date)) d.date = new Date(d.date);
+        });
+    });
+
+    // Declare the x (horizontal position) scale.
+    const x = d3.scaleTime()
+        .domain(d3.extent(dataSets.flat(), d => d.date))
+        .range([marginLeft, width - marginRight]);
+
+    // Declare the y (vertical position) scale.
+    const y = d3.scaleLinear()
+        .domain([0, d3.max(dataSets.flat(), d => d.value)])
+        .range([height - marginBottom, marginTop]);
+
+    // Color palette for the lines.
+    const colors = d3.schemeTableau10;
+
+    // Array to keep track of which datasets are visible.
+    let visibility = new Array(dataSets.length).fill(true);
+
+    // Create the SVG container.
+    const svg = d3.create("svg")
+        .attr("width", width)
+        .attr("height", height)
+        .attr("viewBox", [0, 0, width, height])
+        .attr("overflow", "visible")
+        .attr("style", "max-width: 100%; height: auto; height: intrinsic;");
+
+    // Add the x-axis.
+    svg.append("g")
+        .attr("transform", `translate(0,${height - marginBottom})`)
+        .call(d3.axisBottom(x).ticks(width / 80).tickSizeOuter(0));
+
+    // Add the y-axis, remove the domain line, add grid lines and a label.
+    svg.append("g")
+        .attr("transform", `translate(${marginLeft},0)`)
+        .call(d3.axisLeft(y).ticks(height / 40))
+        .call(g => g.select(".domain").remove())
+        .call(g => g.selectAll(".tick line").clone()
+            .attr("x2", width - marginLeft - marginRight)
+            .attr("stroke-opacity", 0.1))
+        .call(g => g.append("text")
+            .attr("x", -marginLeft)
+            .attr("y", 10)
+            .attr("fill", "currentColor")
+            .attr("text-anchor", "start")
+            .text("↑ Success Rate"));
+
+    // Add lines to the graph.
+    const lines = dataSets.map((dataSet, i) => {
+        const line = d3.line()
+            .defined(d => !isNaN(d.value))
+            .x(d => x(d.date))
+            .y(d => y(d.value));
+
+        return svg.append("path")
+            .datum(dataSet)
+            .attr("fill", "none")
+            .attr("stroke", colors[i % colors.length])
+            .attr("stroke-width", 1.5)
+            .attr("d", line)
+            .attr("class", `line line-${i}`);
+    });
+
+    // Add a legend.
+    const legend = svg.selectAll(".legend")
+        .data(dataSets)
+        .enter().append("g")
+        .attr("class", "legend")
+        .attr("transform", (d, i) => `translate(${width - marginRight + 100}, ${i * 20})`) // Position adjusted to the right
+        .style("font", "10px sans-serif")
+        .style("cursor", "pointer")
+        .on("click", function (event, d) {
+            const index = dataSets.indexOf(d);
+            visibility[index] = !visibility[index];
+            d3.select(lines[index].node()).style("opacity", visibility[index] ? 1 : 0);
+            d3.select(this).style("opacity", visibility[index] ? 1 : 0.5); // Adjust the legend item's opacity
+        });
+
+    // Function to dispatch a click event
+    function dispatchClick(element) {
+        const clickEvent = new MouseEvent('click', {
+            'view': window,
+            'bubbles': true,
+            'cancelable': true
+        });
+        element.dispatchEvent(clickEvent);
+    }
+
+    // Select all '.legend' group elements and click on all but the first three
+    svg.selectAll(".legend")
+        .each(function(d, i) {
+            if (i >= 3) { // Skip the first three
+                dispatchClick(this);
+            }
+        });
+
+    // Add colored rectangles to the legend.
+    legend.append("rect")
+        .attr("x", -18)
+        .attr("width", 18)
+        .attr("height", 18)
+        .attr("fill", (d, i) => colors[i % colors.length]);
+
+    // Add text to the legend.
+    const labels = ["All", "Latest", "Random", "Oldest", "All Headers", "All Bodies", "All Receipts", "Latest Headers", "Latest Bodies", "Latest Receipts", "Random Headers", "Random Bodies", "Random Receipts"];
+    legend.append("text")
+        .attr("x", -24)
+        .attr("y", 9)
+        .attr("dy", ".35em")
+        .attr("text-anchor", "end")
+        .text((d, i) => labels[i])
+        .attr("class", "legend-text");
+
+    return svg.node();
+}
+
+function convertDataForChart(data) {
+    const successRateKeys = [
+        'success_rate_all',
+        'success_rate_latest',
+        'success_rate_random',
+        'success_rate_oldest',
+        'success_rate_all_headers',
+        'success_rate_all_bodies',
+        'success_rate_all_receipts',
+        'success_rate_latest_headers',
+        'success_rate_latest_bodies',
+        'success_rate_latest_receipts',
+        'success_rate_random_headers',
+        'success_rate_random_bodies',
+        'success_rate_random_receipts',
+    ];
+
+    return successRateKeys.map(key =>
+        data.map(d => ({
+            date: new Date(d.timestamp),
+            value: d[key]
+        }))
+    );
+}
+
+// Fetch the stats records from the API.
+function getStatsRecords() {
+    const baseUrl = "api/stat-history/";
+
+    return fetch(`${baseUrl}`)
+        .then(response => {
+            if (!response.ok) {
+                throw new Error('Network response was not ok');
+            }
+            return response.json();
+        })
+        .catch(error => {
+            console.error('There was a problem with the fetch operation:', error.message);
+        });
+}
+
+// Create the stats history chart using data from the API and add it to the DOM.
+async function statsHistoryChart() {
+    try {
+        const data = await getStatsRecords();
+        console.log(data);
+
+        let dataSets = convertDataForChart(data);
+        console.log(dataSets)
+        if (dataSets && dataSets.length > 0) {
+            document.getElementById('stats-history-graph').appendChild(createMultiLineChart(400, 670, dataSets));
+        } else {
+            console.log('No data available to plot the stats chart');
+        }
+    } catch (error) {
+        console.error('There was an error processing your request:', error.message);
+    }
+}

--- a/glados-web/src/lib.rs
+++ b/glados-web/src/lib.rs
@@ -93,6 +93,7 @@ pub async fn run_glados_web(config: Arc<State>) -> Result<()> {
             "/api/is-content-in-deadzone/:content_key",
             get(routes::is_content_in_deadzone),
         )
+        .route("/api/stat-history/", get(routes::get_audit_stats_handler))
         .nest_service("/static/", serve_dir.clone())
         .fallback_service(serve_dir)
         .layer(Extension(config));

--- a/glados-web/src/templates.rs
+++ b/glados-web/src/templates.rs
@@ -6,15 +6,16 @@ use axum::{
 use entity::{client_info, content, content_audit, execution_metadata, key_value, node, record};
 
 use crate::routes::{
-    CalculatedRadiusChartData, ClientDiversityResult, PaginatedCensusListResult, RawEnr, Stats,
+    CalculatedRadiusChartData, ClientDiversityResult, PaginatedCensusListResult, RawEnr,
 };
+use glados_core::stats::AuditStats;
 
 #[derive(Template)]
 #[template(path = "index.html")]
 pub struct IndexTemplate {
     pub client_diversity_data: Vec<ClientDiversityResult>,
     pub average_radius_chart: Vec<CalculatedRadiusChartData>,
-    pub stats: [Stats; 3],
+    pub stats: [AuditStats; 3],
 }
 
 #[derive(Template)]
@@ -68,7 +69,7 @@ pub type AuditTuple = (content_audit::Model, content::Model, client_info::Model)
 #[derive(Template)]
 #[template(path = "content_dashboard.html")]
 pub struct ContentDashboardTemplate {
-    pub stats: [Stats; 3],
+    pub stats: [AuditStats; 3],
     pub contentid_list: Vec<content::Model>,
     pub audits_of_recent_content: Vec<AuditTuple>,
     pub recent_audits: Vec<AuditTuple>,
@@ -110,7 +111,7 @@ pub struct AuditDashboardTemplate {}
 #[derive(Template)]
 #[template(path = "audit_table.html")]
 pub struct AuditTableTemplate {
-    pub stats: [Stats; 3],
+    pub stats: [AuditStats; 3],
     pub audits: Vec<AuditTuple>,
 }
 

--- a/glados-web/templates/index.html
+++ b/glados-web/templates/index.html
@@ -6,6 +6,8 @@
 <script src="/static/js/d3.min.js"></script>
 <script src="/static/js/piechart.js"></script>
 <script src="/static/js/radiusdensity.js"></script>
+<script src="/static/js/stats_history.js"></script>
+<link href="/static/css/homepage.css" rel="stylesheet">
 {% endblock %}
 
 {% block content %}
@@ -68,7 +70,14 @@
                     </div>
                 </div>
             </div>
-            <div id="hover" style="pointer-events: none; position: absolute; opacity: 0;"></div>
+            <div id="hover" style="pointer-events: none; position: absolute; z-index: 9999; opacity: 0;"></div>
+        </div>
+        <div class="col-lg-7 col-md-12 col-sm-12 margin-bottom">
+            <div class="card pie-box h-100">
+                <div class="card-body">
+                     <div id="stats-history-graph"> </div>
+                </div>
+            </div>
         </div>
     </div>
 </div>
@@ -76,6 +85,8 @@
 <script>
     pie_chart_count({{ client_diversity_data| json | safe }})
     radius_node_id_scatter_chart({{ average_radius_chart| json | safe }})
+    statsHistoryChart()
+
 </script>
 
 {% endblock %}

--- a/migration/src/lib.rs
+++ b/migration/src/lib.rs
@@ -8,6 +8,7 @@ mod m20230511_104823_create_client_info;
 mod m20230511_104830_create_content_audit;
 mod m20230511_104838_create_execution_metadata;
 mod m20230511_104937_create_key_value;
+mod m20231107_004843_create_audit_stats;
 
 pub struct Migrator;
 
@@ -23,6 +24,7 @@ impl MigratorTrait for Migrator {
             Box::new(m20230511_104838_create_execution_metadata::Migration),
             Box::new(m20230511_104937_create_key_value::Migration),
             Box::new(m20230508_111707_create_census_tables::Migration),
+            Box::new(m20231107_004843_create_audit_stats::Migration),
         ]
     }
 }

--- a/migration/src/m20231107_004843_create_audit_stats.rs
+++ b/migration/src/m20231107_004843_create_audit_stats.rs
@@ -1,0 +1,131 @@
+use sea_orm_migration::prelude::*;
+
+#[derive(DeriveMigrationName)]
+pub struct Migration;
+
+#[async_trait::async_trait]
+impl MigrationTrait for Migration {
+    async fn up(&self, manager: &SchemaManager) -> Result<(), DbErr> {
+        let _ = manager
+            .create_table(
+                Table::create()
+                    .table(AuditStats::Table)
+                    .col(
+                        ColumnDef::new(AuditStats::Id)
+                            .integer()
+                            .not_null()
+                            .auto_increment()
+                            .primary_key(),
+                    )
+                    .col(
+                        ColumnDef::new(AuditStats::Timestamp)
+                            .timestamp_with_time_zone()
+                            .not_null(),
+                    )
+                    .col(ColumnDef::new(AuditStats::NumAudits).integer().not_null())
+                    .col(
+                        ColumnDef::new(AuditStats::SuccessRateAll)
+                            .float()
+                            .not_null(),
+                    )
+                    .col(
+                        ColumnDef::new(AuditStats::SuccessRateLatest)
+                            .float()
+                            .not_null(),
+                    )
+                    .col(
+                        ColumnDef::new(AuditStats::SuccessRateRandom)
+                            .float()
+                            .not_null(),
+                    )
+                    .col(
+                        ColumnDef::new(AuditStats::SuccessRateOldest)
+                            .float()
+                            .not_null(),
+                    )
+                    .col(
+                        ColumnDef::new(AuditStats::SuccessRateAllHeaders)
+                            .float()
+                            .not_null(),
+                    )
+                    .col(
+                        ColumnDef::new(AuditStats::SuccessRateAllBodies)
+                            .float()
+                            .not_null(),
+                    )
+                    .col(
+                        ColumnDef::new(AuditStats::SuccessRateAllReceipts)
+                            .float()
+                            .not_null(),
+                    )
+                    .col(
+                        ColumnDef::new(AuditStats::SuccessRateLatestHeaders)
+                            .float()
+                            .not_null(),
+                    )
+                    .col(
+                        ColumnDef::new(AuditStats::SuccessRateLatestBodies)
+                            .float()
+                            .not_null(),
+                    )
+                    .col(
+                        ColumnDef::new(AuditStats::SuccessRateLatestReceipts)
+                            .float()
+                            .not_null(),
+                    )
+                    .col(
+                        ColumnDef::new(AuditStats::SuccessRateRandomHeaders)
+                            .float()
+                            .not_null(),
+                    )
+                    .col(
+                        ColumnDef::new(AuditStats::SuccessRateRandomBodies)
+                            .float()
+                            .not_null(),
+                    )
+                    .col(
+                        ColumnDef::new(AuditStats::SuccessRateRandomReceipts)
+                            .float()
+                            .not_null(),
+                    )
+                    .to_owned(),
+            )
+            .await;
+        manager
+            .create_index(
+                Index::create()
+                    .name("idx_auditstats-time")
+                    .table(AuditStats::Table)
+                    .col(AuditStats::Timestamp)
+                    .to_owned(),
+            )
+            .await
+    }
+
+    async fn down(&self, manager: &SchemaManager) -> Result<(), DbErr> {
+        manager
+            .drop_table(Table::drop().table(AuditStats::Table).to_owned())
+            .await
+    }
+}
+
+#[derive(Iden)]
+pub enum AuditStats {
+    Table,
+    Id,
+    Timestamp,
+    NumAudits,
+    SuccessRateAll,
+    SuccessRateLatest,
+    SuccessRateRandom,
+    SuccessRateOldest,
+    SuccessRateAllHeaders,
+    SuccessRateAllBodies,
+    SuccessRateAllReceipts,
+    SuccessRateLatestHeaders,
+    SuccessRateLatestBodies,
+    SuccessRateLatestReceipts,
+    SuccessRateRandomHeaders,
+    SuccessRateRandomBodies,
+    SuccessRateRandomReceipts,
+}


### PR DESCRIPTION
This PR resolves #164, with a chart instead of the day segments. This aggregate data can be added in a subsequent PR.

The UI is a little rough around the edges, but good enough to be usable. 

The only question on the data gathered is whether I should continue calculating it as the average over the past hour. Maybe doing the average over a smaller period would be better. We've been using the "average over the past hour" metric when discussing glados performance, so that's what I went with.

Changes:

- Adds the `audit_stats` table, where stats for a bunch of different combinations of filters are recorded
- Moves stat calculation logic from `glados-web` to `glados-core` so that both `glados-web` and `glados-audit` can use 
- Adds the `periodically_record_stats` task to `glados-audit`
- Adds the `/api/stat-history/` endpoint
- Adds `stats_history.js` widget, and instantiates it on the index page after requesting the data from the endpoint
- Adds the `--stats-recording-period` flag to `glados-audit`, which defaults to 300 seconds

For local testing purposes I would set the recording period to like 5 seconds so that you get test data reasonably quickly.

![Screen Shot 2023-11-07 at 2 56 46 PM](https://github.com/ethereum/glados/assets/4079737/0b233f5d-cb1a-4788-988b-1ebe1a7f2d22)



