### PR TITLE
Avoid Infura lock-in for docker-compose and add env to readme

### DIFF
--- a/DOCKER_GUIDE.md
+++ b/DOCKER_GUIDE.md
@@ -13,11 +13,13 @@ where Postgres should store its data on the host machine.
 
 - `GLADOS_POSTGRES_PASSWORD` to the password for accessing the DB.
 
+- `GLADOS_PROVIDER_URL` to the execution API provider URL.
+
 Then, from the root of this repo, run:
 
 `docker compose up -d`
 
-If successful, you should be able to navigate to `127.0.0.1:3001/` and see 
+If successful, you should be able to navigate to `127.0.0.1:3001/` and see
 the Glados web dashboard populating with data.
 
 ### Updating
@@ -26,5 +28,5 @@ the Glados web dashboard populating with data.
 
 ### Tearing Down
 
-`docker compose down` will remove the deployment. 
+`docker compose down` will remove the deployment.
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -40,7 +40,7 @@ services:
     restart: always
 
   glados_monitor:
-    command: "--database-url postgres://postgres:${GLADOS_POSTGRES_PASSWORD}@glados_postgres:5432/glados follow-head --provider-url https://mainnet.infura.io/v3/${INFURA_PROJECT_ID?Infura Project ID Required}"
+    command: "--database-url postgres://postgres:${GLADOS_POSTGRES_PASSWORD}@glados_postgres:5432/glados follow-head --provider-url ${GLADOS_PROVIDER_URL?Glados monitor provider URL required}"
     image: portalnetwork/glados-monitor:latest
     environment:
       RUST_LOG: warn,glados_monitor=info


### PR DESCRIPTION
This allows the user to use any node or service as long as it supports the EL JSON-RPC API.