### PR TITLE
Add support for Fluffy in the docker compose file

### DIFF
--- a/DOCKER_GUIDE.md
+++ b/DOCKER_GUIDE.md
@@ -15,6 +15,9 @@ where Postgres should store its data on the host machine.
 
 - `GLADOS_PROVIDER_URL` to the execution API provider URL.
 
+- `GLADOS_PORTAL_CLIENT` to the Portal client to be used for Portal network
+access. Currently supported values are `trin` and `fluffy`.
+
 Then, from the root of this repo, run:
 
 `docker compose up -d`

--- a/docker-compose-clients.yml
+++ b/docker-compose-clients.yml
@@ -1,0 +1,10 @@
+services:
+  trin:
+    image: portalnetwork/trin:latest
+    environment:
+      RUST_LOG: info
+    command: "--web3-transport http --web3-http-address http://0.0.0.0:8545/ --mb 0 --bootnodes default"
+
+  fluffy:
+    image: statusim/nimbus-fluffy:amd64-master-latest
+    command: "--rpc --rpc-address=0.0.0.0 --storage-capacity=0"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -15,12 +15,11 @@ services:
       - glados-net
     restart: always
 
-  trin:
-    hostname: trin
-    image: portalnetwork/trin:latest
-    environment:
-      RUST_LOG: info
-    command: "--web3-transport http --web3-http-address http://0.0.0.0:8545/ --mb 0 --bootnodes default"
+  portal_client:
+    extends:
+      file: docker-compose-clients.yml
+      service: ${GLADOS_PORTAL_CLIENT?Glados portal client required}
+    hostname: portal-client
     ports:
       - "8545:8545"
     networks:
@@ -28,13 +27,13 @@ services:
     restart: always
 
   glados_audit:
-    command: "--database-url postgres://postgres:${GLADOS_POSTGRES_PASSWORD}@glados_postgres:5432/glados --portal-client http://trin:8545 --concurrency 8 --latest-strategy-weight 2"
+    command: "--database-url postgres://postgres:${GLADOS_POSTGRES_PASSWORD}@glados_postgres:5432/glados --portal-client http://portal-client:8545 --concurrency 8 --latest-strategy-weight 2"
     image: portalnetwork/glados-audit:latest
     environment:
       RUST_LOG: warn,glados_audit=info
     depends_on:
       - glados_postgres
-      - trin
+      - portal_client
     networks:
       - glados-net
     restart: always
@@ -66,14 +65,14 @@ services:
     restart: always
 
   glados_cartographer:
-    command: "--database-url postgres://postgres:${GLADOS_POSTGRES_PASSWORD}@glados_postgres:5432/glados --transport http --http-url http://trin:8545 --concurrency 10"
+    command: "--database-url postgres://postgres:${GLADOS_POSTGRES_PASSWORD}@glados_postgres:5432/glados --transport http --http-url http://portal-client:8545 --concurrency 10"
     image: portalnetwork/glados-cartographer:latest
     environment:
       RUST_LOG: warn,glados_cartographer=info
     depends_on:
       - glados_web
       - glados_postgres
-      - trin
+      - portal_client
     networks:
       - glados-net
     restart: always


### PR DESCRIPTION
I went the route of using an `GLADOS_PORTAL_CLIENT` env var to select the client, as there are already several of those required anyhow. That way we can stick with just the default `docker-compose.yml`.

I used `extends` instead of `include` as the latter is only for fairly recent docker-compose versions.

Another option would be to create a docker compose file for each client and extends/include some common compose file. Not sure what is more idiomatic in Docker land.

~~This PR is in Draft because I haven't been able to fully test the final version as I'm hitting https://github.com/ethereum/glados/issues/205~~ Have been able to test it in the meanwhile.