### PR TITLE
fix: run portal-client on host instead of docker bridge network

### DIFF
--- a/docker-compose-clients.yml
+++ b/docker-compose-clients.yml
@@ -3,7 +3,7 @@ services:
     image: portalnetwork/trin:latest
     environment:
       RUST_LOG: info
-    command: "--web3-transport http --web3-http-address http://0.0.0.0:8545/ --mb 0 --bootnodes default"
+    command: "--web3-transport http --web3-http-address http://0.0.0.0:8545/ --mb 0 --no-upnp"
 
   fluffy:
     image: statusim/nimbus-fluffy:amd64-master-latest

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -20,14 +20,11 @@ services:
       file: docker-compose-clients.yml
       service: ${GLADOS_PORTAL_CLIENT?Glados portal client required}
     hostname: portal-client
-    ports:
-      - "8545:8545"
-    networks:
-      - glados-net
+    network_mode: "host"
     restart: always
 
   glados_audit:
-    command: "--database-url postgres://postgres:${GLADOS_POSTGRES_PASSWORD}@glados_postgres:5432/glados --portal-client http://portal-client:8545 --concurrency 8 --latest-strategy-weight 2"
+    command: "--database-url postgres://postgres:${GLADOS_POSTGRES_PASSWORD}@glados_postgres:5432/glados --portal-client http://host.docker.internal:8545 --concurrency 8 --latest-strategy-weight 2"
     image: portalnetwork/glados-audit:latest
     environment:
       RUST_LOG: warn,glados_audit=info
@@ -36,6 +33,8 @@ services:
       - portal_client
     networks:
       - glados-net
+    extra_hosts:
+      - "host.docker.internal:host-gateway"
     restart: always
 
   glados_monitor:
@@ -65,7 +64,7 @@ services:
     restart: always
 
   glados_cartographer:
-    command: "--database-url postgres://postgres:${GLADOS_POSTGRES_PASSWORD}@glados_postgres:5432/glados --transport http --http-url http://portal-client:8545 --concurrency 10"
+    command: "--database-url postgres://postgres:${GLADOS_POSTGRES_PASSWORD}@glados_postgres:5432/glados --transport http --http-url http://host.docker.internal:8545 --concurrency 10"
     image: portalnetwork/glados-cartographer:latest
     environment:
       RUST_LOG: warn,glados_cartographer=info
@@ -75,6 +74,8 @@ services:
       - portal_client
     networks:
       - glados-net
+    extra_hosts:
+      - "host.docker.internal:host-gateway"
     restart: always
 
 networks:


### PR DESCRIPTION
# intro to problem
Trin wasn't looking so good on the glados client diversity graph one major reason for this was NAT issues. Trin running using our docker compose setup had Trin running in a docker bridge network. This is somewhat of a similar situation the Trin nodes behind NAT would be faced with, a key note is techniques like UPNP don't work on docker bridge networks.

Regardless it looks like sigp/discv5 has already thought through some problems with nat traversal years ago.

In sigp/discv5 they have a IP:Port voting mechanism where the majority of different nodes that contact your node can end up changing you IP:Port depending on what they say. I do not know the effectiveness of it, it could have also been skewing/making things worse I am not 100% sure  yet.

On our testnet I could see warning such as ``Session has invalid ENR. Enr sockets: Some(167.172.225.20:60773), None. Expected: Node: 0x58cd..efa9, addr: 167.172.225.20:12093``

Happening all the time. Different nodes could ping glados trin and they would get through, but they would then error out for that reason

So maybe docker's bridge network was redirecting multiple incoming port traffic to the binded port on trin? so other nodes could see many Ports working.

# solution
I don't think glados is the place to be debugging NAT problems. So after trying for a bit I think it is best if we just remove the NAT problem, but running trin on the host network instead.