### PR TITLE
feat: add census nodes timeline chart

### DIFF
--- a/entity/src/census_node.rs
+++ b/entity/src/census_node.rs
@@ -26,6 +26,14 @@ pub enum Relation {
         on_delete = "Cascade"
     )]
     Census,
+    #[sea_orm(
+        belongs_to = "super::record::Entity",
+        from = "Column::RecordId"
+        to = "super::record::Column::Id",
+        on_update = "Cascade",
+        on_delete = "Cascade"
+    )]
+    Record,
 }
 
 impl Related<super::census::Entity> for Entity {

--- a/glados-web/assets/js/census-timeseries.js
+++ b/glados-web/assets/js/census-timeseries.js
@@ -1,5 +1,3 @@
-
-
 function createSquareChart(height, width, data) {
 
     // Incoming data takes the form:
@@ -18,49 +16,22 @@ function createSquareChart(height, width, data) {
               null,
             ]
           },
+          ...
         ]
       }*/
 
     // Declare the chart dimensions and margins.
+    const marginTop = 80;
     const marginLeft = 40;
 
     // Create a combined array of node IDs and their statuses.
-    const nodesAndEnrStatuses = data.node_ids.map((nodeId, index) => {
+    const nodesAndEnrStatuses = zipNodesAndCensusData(data.node_ids, data.censuses);
 
-        // Use the latest ENR for display & sorting.
-        let enrString = data.censuses[data.censuses.length - 1].enr_statuses[index];
-        let clientName = null;
-        if (enrString) {
-            let {enr: decodedEnr, seq, signature} = ENR.ENR.decodeTxt(enrString);
-            
-            for (let [key, value] of decodedEnr.entries()) {
-                if (key === "c") {
-                    let fullClientString = String.fromCharCode.apply(null, value);
-                    if (fullClientString[0] === 'f') {
-                        clientName = "fluffy";
-                    } 
-                    else if (fullClientString[0] === 't') {
-                        clientName = "trin";
-                        clientName += fullClientString.substring(2);
-                    } else {
-                        clientName = fullClientString;
-                    }
-
-                }
-            }
-        }
-        return {
-            nodeId: nodeId,
-            latestClientString: clientName,
-            statuses: data.censuses.map(census => census.enr_statuses[index])
-        };
-    });
-
-    console.log(nodesAndEnrStatuses);
-
-    // Sort the combined array based on latestClientString and nodeId
+    // Sort the combined array based on latestClientString and secondarily nodeId
     nodesAndEnrStatuses.sort((a, b) => {
-        // First, compare by latestClientString
+        // Place empty at the end instead of front
+        if (a.latestClientString === null && b.latestClientString !== null) return 1;
+        if (a.latestClientString !== null && b.latestClientString === null) return -1;
         const clientComparison = (a.latestClientString || "").localeCompare(b.latestClientString || "");
         if (clientComparison !== 0) {
             return clientComparison;
@@ -68,29 +39,59 @@ function createSquareChart(height, width, data) {
         // If latestClientString is equal, then compare by nodeId
         return a.nodeId.localeCompare(b.nodeId);
     });
-    const nodes = nodesAndEnrStatuses.map(d => d.nodeId);
 
     const x = d3.scaleTime()
         .domain(d3.extent(data.censuses, d => new Date(d.time)))
         .range([0, width]);
 
+    const nodes = nodesAndEnrStatuses.map(d => d.nodeId);
     const y = d3.scaleBand()
         .domain(nodes)
         .range([0, height])
-        .padding(0.1);  
+        .padding(0.05);  
+
+    // Parameters for handling scaling of rows.
+    const originalHeight = y.bandwidth();
+    const expandedScaleFactor = 12.0;
+    const expandedCellHeight = (originalHeight * expandedScaleFactor)
         
     // Create the SVG container.
     const svg = d3.create("svg")
         .attr("width", width)
-        .attr("height", height)
-        .attr("viewBox", [0, 0, width, height])
+        .attr("height", height + expandedCellHeight + marginTop)
+        .attr("viewBox", [0, 0, width, height + expandedCellHeight + marginTop])
         .attr("overflow", "visible")
         .attr("style", "max-width: 100%; height: auto; height: intrinsic;");
+
+    // Append the title
+    svg.append("text")
+       .attr("x", width / 2)
+       .attr("y", 10)
+       .attr("text-anchor", "middle")
+       .style("font-size", "24px")
+       .text("24 Hour Census Results");
+
+    // Append the subtitle
+    svg.append("text")
+        .attr("x", width / 2)
+        .attr("y", 40)
+        .attr("text-anchor", "middle")
+        .style("font-size", "16px")
+        .text(`24 hour period beginning ${data.censuses[0].time}`);
     
+    // Append X axis to the bottom and top
     svg.append("g")
-        .attr("transform", `translate(0,${height})`)
+        .attr("transform", `translate(0,${marginTop + height})`)
         .attr("class", "x-axis")
-        .call(d3.axisBottom(x));
+        .call(d3.axisBottom(x))
+        .selectAll("text")
+        .style("font-size", "12px");
+    svg.append("g")
+        .attr("transform", `translate(0,${marginTop})`)
+        .attr("class", "x-axis")
+        .call(d3.axisTop(x))
+        .selectAll("text")
+        .style("font-size", "12px");
 
     // Create group for each row.
     const rowGroups = svg.selectAll(".row-group")
@@ -100,35 +101,48 @@ function createSquareChart(height, width, data) {
         .attr("class", "row-group")
         .attr("id", (d, i) => `row-${i}`);
 
+    rowGroups.attr("transform", `translate(0, ${marginTop})`);
+
     // Append squares to each row group.
     rowGroups.each(function(node, i) {
         node.statuses.forEach((censusResult, j) => {
             const status = censusResult;
-            const rectangle = d3.select(this).append("a")
-                .attr("xlink:href", `/census/?census-id=${data.censuses[j].census_id}`)
-                .attr("target", "_blank");
-            rectangle.append("rect")
-                .attr("x", x(new Date(data.censuses[j].time)))
-                .attr("y", y(node.nodeId))
-                .attr("data-original-y", y(node.nodeId))
-                .attr("width", 20)
-                .attr("height", y.bandwidth())
-                .attr("fill", status ? "green" : "gray")
-                .on("mouseover", function() {
-                    d3.select(this)
-                        .style("stroke", "white") 
-                        .style("stroke-width", 3);
-                }).on("mouseout", function() {
-                    d3.select(this)
-                        .style("stroke", null) 
-                        .style("stroke-width", null); 
-                }).append("a")
-                .attr("xlink:href", d => `/census/?census-id=${data.censuses[j].census_id}`)
-                .attr("target", "_blank");
+
+            const row = d3.select(this);
+            const rect = row.append("rect")
+              .attr("x", x(new Date(data.censuses[j].time)))
+              .attr("y", y(node.nodeId))
+              .attr("width", 17)
+              .attr("height", y.bandwidth())
+              .attr("fill", status ? "green" : "gray");
+
+            let title = "";
+            if (censusResult) {
+                title = createHoverOverInfoFromENR(censusResult, data.censuses[j].time);
+            } else {
+                title = `Not found during the census beginning at ${data.censuses[j].time}.`;
+            }
+
+            rect.append("title").text(title);
+
+            rect.on("click", function(event, d) {
+                window.open(`/census/?census-id=${data.censuses[j].census_id}`, '_blank');
+            });
+            
+            rect.on("mouseover", function(event) {
+                row.raise();
+                rect.raise()
+                     .style("stroke", "white")
+                     .style("stroke-width", 4);
+            }).on("mouseout", function() {
+                d3.select(this)
+                  .style("stroke", null) 
+                .style("stroke-width", null); 
+            });
         });
     });
 
-    // Append y-axis labels to each row group
+    // Append y-axis labels/link to each row group
     rowGroups.append("a")
         .attr("xlink:href", d => `/network/node/${d.nodeId}/`)
         .attr("target", "_blank")
@@ -139,20 +153,25 @@ function createSquareChart(height, width, data) {
         .attr("text-anchor", "end")
         .text(d => (d.nodeId.substring(0, 6) + '...' + d.nodeId.substring(d.nodeId.length - 4)));
 
-      
-    // Parameters for handling scaling of rows.
-    const originalHeight = y.bandwidth();
-    const scaleYFactor = 12.0;
-    const fullScaleFactor = scaleYFactor;
-    const adjacentScaleFactor = 0.3 * scaleYFactor;
-    const nextScaleFactor = 0.2 * scaleYFactor;
-    const maxExpandedHeight = (originalHeight * fullScaleFactor)
-                             + ( 2 * originalHeight * adjacentScaleFactor);
-                             + ( 2 * originalHeight * nextScaleFactor);
     // Internal function to handle hover-over magnification effect.
     function highlightNode(node) {
         let hoveredIndex = nodes.indexOf(node.nodeId);
-        let accumulatedShift = 0;
+        let downwardShift = 0;
+
+        // Push x axis down to fit expanded rows
+        svg.select("g.x-axis")
+            .attr("transform", `translate(0,${height + expandedCellHeight + marginTop - originalHeight})`);
+        svg.attr("height", height + expandedCellHeight + marginTop);
+
+         // Reset all rows to their original positions and heights, if necessary
+         rowGroups.attr("transform", null)
+            .selectAll("rect")
+            .attr("height", originalHeight);
+
+         // Reset font size and position of text, if necessary
+         rowGroups.selectAll("text")
+             .style("font-size", null) // Reset font size
+             .attr("y", d => y(d.nodeId) + originalHeight / 2);
 
         // Remove existing client string labels if any.
         svg.selectAll(".client-string-label").remove();
@@ -162,30 +181,26 @@ function createSquareChart(height, width, data) {
             let scaleFactor, heightIncrease;
     
             if (index === hoveredIndex) {
-                scaleFactor = fullScaleFactor;
-            } else if (index === hoveredIndex - 1 || index === hoveredIndex + 1) {
-                scaleFactor = adjacentScaleFactor;
-            } else if (index === hoveredIndex - 2 || index === hoveredIndex + 2) {
-                scaleFactor = nextScaleFactor;
+                scaleFactor = expandedScaleFactor;
+                // Adjust the height of the row
+                group.selectAll("rect")
+                    .attr("height", expandedCellHeight);
             } else {
                 scaleFactor = 1;
             }
     
             heightIncrease = (originalHeight * scaleFactor) - originalHeight;
-            accumulatedShift += heightIncrease;
+            downwardShift += heightIncrease;
     
-            // Adjust the height of the row
-            group.selectAll("rect")
-                .attr("height", originalHeight * scaleFactor);
-
             // Adjust the font size and position of the text
             group.selectAll("text")
-                .style("font-size", `${1 + (0.7 * ((scaleFactor - 1) / (fullScaleFactor - 1)))}em`)
+                .style("font-size", `${1 + (0.7 * ((scaleFactor - 1) / (expandedScaleFactor - 1)))}em`)
                 .attr("y", y(nodesAndEnrStatuses[index].nodeId) + (originalHeight * scaleFactor) / 2);
     
             // Shift rows below the hovered row downwards
-            group.attr("transform", `translate(0, ${accumulatedShift - heightIncrease})`);
+            group.attr("transform", `translate(0, ${marginTop + (downwardShift - heightIncrease)})`);
 
+            // Append metadata
             if (index === hoveredIndex) {
                 const yPos = y(nodesAndEnrStatuses[index].nodeId) + (originalHeight * scaleFactor) / 2;
 
@@ -203,31 +218,76 @@ function createSquareChart(height, width, data) {
 
     // Apply hover effect to the row groups
     rowGroups.on("mouseover", function(_, node) {
-
-        // Push x axis down to fit expanded rows
-        svg.select("g.x-axis")
-            .attr("transform", `translate(0,${height + maxExpandedHeight})`);
-        svg.attr("height", height + maxExpandedHeight);
-
-         // Reset all rows to their original positions and heights
-         rowGroups.attr("transform", null)
-         .selectAll("rect")
-         .attr("height", originalHeight);
-
-         // Reset font size and position of text
-         rowGroups.selectAll("text")
-             .style("font-size", null) // Reset font size
-             .attr("y", d => y(d.nodeId) + originalHeight / 2);
-
         highlightNode(node);
     });
 
     return svg.node();
 }
 
+// Combines decoupled node and census response from API
+function zipNodesAndCensusData(nodes, censuses) {
+    return nodes.map((nodeId, index) => {
+
+        // Use the latest ENR for display & sorting.
+        let enrString = censuses[censuses.length - 1].enr_statuses[index];
+        let clientName = null;
+        if (enrString) {
+            let {enr: decodedEnr, seq, signature} = ENR.ENR.decodeTxt(enrString);
+            
+            for (let [key, value] of decodedEnr.entries()) {
+                if (key === "c") {
+                    let fullClientString = String.fromCharCode.apply(null, value);
+                    if (fullClientString[0] === 'f') {
+                        clientName = "fluffy ";
+                    } 
+                    else if (fullClientString[0] === 't') {
+                        clientName = "trin ";
+                        clientName += fullClientString.substring(2);
+                    } else {
+                        clientName = fullClientString;
+                    }
+
+                }
+            }
+        }
+        return {
+            nodeId: nodeId,
+            latestClientString: clientName,
+            statuses: censuses.map(census => census.enr_statuses[index])
+        };
+    });
+}
+
+// Helper function for creating hover-over text.
+function createHoverOverInfoFromENR(enr, time) {
+
+    let {enr: decodedEnr, seq, signature} = ENR.ENR.decodeTxt(enr);
+    let ip = decodedEnr["ip"];
+    let port = decodedEnr["udp"];
+    let shortenedEnr = enr.substring(0, 15) + '...' + enr.substring(enr.length - 10);
+    let clientString = getClientStringFromDecodedEnr(decodedEnr);
+    title = `Node found during census beginning at ${time}.\nENR: ${shortenedEnr}\nIP: ${ip}:${port}\nSeq: ${seq}\nClient String: ${clientString}`;
+
+    return title;
+
+}
+
+function getClientStringFromDecodedEnr(decodedEnr) {
+    for (let [key, value] of decodedEnr.entries()) {
+
+        if (key === "c") {
+            return String.fromCharCode.apply(null, value);
+        } else {
+            return "";
+        }
+    }
+
+}
+
 // Fetch the census node records from the API.
-function getCensusTimeSeriesData() {
-    const baseUrl = "api/census-node-timeseries/";
+async function getCensusTimeSeriesData(daysAgo) {
+
+    const baseUrl = `census-node-timeseries-data/?days-ago=daysAgo`;
 
     return fetch(`${baseUrl}`)
         .then(response => {
@@ -244,7 +304,6 @@ function getCensusTimeSeriesData() {
 // Create the census node timeseries chart using data from the API and add it to the DOM.
 async function censusTimeSeriesChart() {
         const data = await getCensusTimeSeriesData();
-        console.log(data);
 
         if (data) {
             document.getElementById('census-timeseries-graph').appendChild(createSquareChart(1700, 1700, data));

--- a/glados-web/assets/js/census-timeseries.js
+++ b/glados-web/assets/js/census-timeseries.js
@@ -1,0 +1,254 @@
+
+
+function createSquareChart(height, width, data) {
+
+    // Incoming data takes the form:
+   /*{
+        "node_ids": [
+          "0x9891fe3fdfcec2707f877306fc6e5596b1405fedf70ad2911496c2ac40dfeda5",
+          "0x08653f55f8120591717aae0426c10c25f0e6a7db078c2e1516b4f3059cefff35",
+          "0xbefb246b22757267608a436d265018374592291f284c536f73c933b29a91e10a"
+        ],
+        "censuses": [
+          {
+            "time": "2023-12-13T02:03:38.389580Z",
+            "enr_statuses": [
+              "enr:-Jy4QOOcmr_MEnF8HacDDUxXjCkaMDsvij3-lNBg...mlwhM69ZOyJc2VjcDI1NmsxoQNhyC_neIY2fOKxBi8UGBvnZiBcWbChOHq73nNxeu0ELYN1ZHCCIzE",
+              null,
+              null,
+            ]
+          },
+        ]
+      }*/
+
+    // Declare the chart dimensions and margins.
+    const marginLeft = 40;
+
+    // Create a combined array of node IDs and their statuses.
+    const nodesAndEnrStatuses = data.node_ids.map((nodeId, index) => {
+
+        // Use the latest ENR for display & sorting.
+        let enrString = data.censuses[data.censuses.length - 1].enr_statuses[index];
+        let clientName = null;
+        if (enrString) {
+            let {enr: decodedEnr, seq, signature} = ENR.ENR.decodeTxt(enrString);
+            
+            for (let [key, value] of decodedEnr.entries()) {
+                if (key === "c") {
+                    let fullClientString = String.fromCharCode.apply(null, value);
+                    if (fullClientString[0] === 'f') {
+                        clientName = "fluffy";
+                    } 
+                    else if (fullClientString[0] === 't') {
+                        clientName = "trin";
+                        clientName += fullClientString.substring(2);
+                    } else {
+                        clientName = fullClientString;
+                    }
+
+                }
+            }
+        }
+        return {
+            nodeId: nodeId,
+            latestClientString: clientName,
+            statuses: data.censuses.map(census => census.enr_statuses[index])
+        };
+    });
+
+    console.log(nodesAndEnrStatuses);
+
+    // Sort the combined array based on latestClientString and nodeId
+    nodesAndEnrStatuses.sort((a, b) => {
+        // First, compare by latestClientString
+        const clientComparison = (a.latestClientString || "").localeCompare(b.latestClientString || "");
+        if (clientComparison !== 0) {
+            return clientComparison;
+        }
+        // If latestClientString is equal, then compare by nodeId
+        return a.nodeId.localeCompare(b.nodeId);
+    });
+    const nodes = nodesAndEnrStatuses.map(d => d.nodeId);
+
+    const x = d3.scaleTime()
+        .domain(d3.extent(data.censuses, d => new Date(d.time)))
+        .range([0, width]);
+
+    const y = d3.scaleBand()
+        .domain(nodes)
+        .range([0, height])
+        .padding(0.1);  
+        
+    // Create the SVG container.
+    const svg = d3.create("svg")
+        .attr("width", width)
+        .attr("height", height)
+        .attr("viewBox", [0, 0, width, height])
+        .attr("overflow", "visible")
+        .attr("style", "max-width: 100%; height: auto; height: intrinsic;");
+    
+    svg.append("g")
+        .attr("transform", `translate(0,${height})`)
+        .attr("class", "x-axis")
+        .call(d3.axisBottom(x));
+
+    // Create group for each row.
+    const rowGroups = svg.selectAll(".row-group")
+        .data(nodesAndEnrStatuses)
+        .enter()
+        .append("g")
+        .attr("class", "row-group")
+        .attr("id", (d, i) => `row-${i}`);
+
+    // Append squares to each row group.
+    rowGroups.each(function(node, i) {
+        node.statuses.forEach((censusResult, j) => {
+            const status = censusResult;
+            const rectangle = d3.select(this).append("a")
+                .attr("xlink:href", `/census/?census-id=${data.censuses[j].census_id}`)
+                .attr("target", "_blank");
+            rectangle.append("rect")
+                .attr("x", x(new Date(data.censuses[j].time)))
+                .attr("y", y(node.nodeId))
+                .attr("data-original-y", y(node.nodeId))
+                .attr("width", 20)
+                .attr("height", y.bandwidth())
+                .attr("fill", status ? "green" : "gray")
+                .on("mouseover", function() {
+                    d3.select(this)
+                        .style("stroke", "white") 
+                        .style("stroke-width", 3);
+                }).on("mouseout", function() {
+                    d3.select(this)
+                        .style("stroke", null) 
+                        .style("stroke-width", null); 
+                }).append("a")
+                .attr("xlink:href", d => `/census/?census-id=${data.censuses[j].census_id}`)
+                .attr("target", "_blank");
+        });
+    });
+
+    // Append y-axis labels to each row group
+    rowGroups.append("a")
+        .attr("xlink:href", d => `/network/node/${d.nodeId}/`)
+        .attr("target", "_blank")
+        .append("text")
+        .attr("x", -marginLeft)
+        .attr("y", d => y(d.nodeId) + y.bandwidth() / 2)
+        .attr("dy", ".35em")
+        .attr("text-anchor", "end")
+        .text(d => (d.nodeId.substring(0, 6) + '...' + d.nodeId.substring(d.nodeId.length - 4)));
+
+      
+    // Parameters for handling scaling of rows.
+    const originalHeight = y.bandwidth();
+    const scaleYFactor = 12.0;
+    const fullScaleFactor = scaleYFactor;
+    const adjacentScaleFactor = 0.3 * scaleYFactor;
+    const nextScaleFactor = 0.2 * scaleYFactor;
+    const maxExpandedHeight = (originalHeight * fullScaleFactor)
+                             + ( 2 * originalHeight * adjacentScaleFactor);
+                             + ( 2 * originalHeight * nextScaleFactor);
+    // Internal function to handle hover-over magnification effect.
+    function highlightNode(node) {
+        let hoveredIndex = nodes.indexOf(node.nodeId);
+        let accumulatedShift = 0;
+
+        // Remove existing client string labels if any.
+        svg.selectAll(".client-string-label").remove();
+
+        rowGroups.each(function(_, index) {
+            const group = d3.select(this);
+            let scaleFactor, heightIncrease;
+    
+            if (index === hoveredIndex) {
+                scaleFactor = fullScaleFactor;
+            } else if (index === hoveredIndex - 1 || index === hoveredIndex + 1) {
+                scaleFactor = adjacentScaleFactor;
+            } else if (index === hoveredIndex - 2 || index === hoveredIndex + 2) {
+                scaleFactor = nextScaleFactor;
+            } else {
+                scaleFactor = 1;
+            }
+    
+            heightIncrease = (originalHeight * scaleFactor) - originalHeight;
+            accumulatedShift += heightIncrease;
+    
+            // Adjust the height of the row
+            group.selectAll("rect")
+                .attr("height", originalHeight * scaleFactor);
+
+            // Adjust the font size and position of the text
+            group.selectAll("text")
+                .style("font-size", `${1 + (0.7 * ((scaleFactor - 1) / (fullScaleFactor - 1)))}em`)
+                .attr("y", y(nodesAndEnrStatuses[index].nodeId) + (originalHeight * scaleFactor) / 2);
+    
+            // Shift rows below the hovered row downwards
+            group.attr("transform", `translate(0, ${accumulatedShift - heightIncrease})`);
+
+            if (index === hoveredIndex) {
+                const yPos = y(nodesAndEnrStatuses[index].nodeId) + (originalHeight * scaleFactor) / 2;
+
+                // Append a new text element for latestClientString
+                group.append("text")
+                    .attr("class", "client-string-label")
+                    .attr("x", -200)
+                    .attr("y", yPos + 30) // Adjust this to position the label correctly
+                    .attr("text-anchor", "start")
+                    .text(nodesAndEnrStatuses[index].latestClientString);
+            }
+
+        });
+    }
+
+    // Apply hover effect to the row groups
+    rowGroups.on("mouseover", function(_, node) {
+
+        // Push x axis down to fit expanded rows
+        svg.select("g.x-axis")
+            .attr("transform", `translate(0,${height + maxExpandedHeight})`);
+        svg.attr("height", height + maxExpandedHeight);
+
+         // Reset all rows to their original positions and heights
+         rowGroups.attr("transform", null)
+         .selectAll("rect")
+         .attr("height", originalHeight);
+
+         // Reset font size and position of text
+         rowGroups.selectAll("text")
+             .style("font-size", null) // Reset font size
+             .attr("y", d => y(d.nodeId) + originalHeight / 2);
+
+        highlightNode(node);
+    });
+
+    return svg.node();
+}
+
+// Fetch the census node records from the API.
+function getCensusTimeSeriesData() {
+    const baseUrl = "api/census-node-timeseries/";
+
+    return fetch(`${baseUrl}`)
+        .then(response => {
+            if (!response.ok) {
+                throw new Error('Network response was not ok');
+            }
+            return response.json();
+        })
+        .catch(error => {
+            console.error('There was a problem with the fetch operation:', error.message);
+        });
+}
+
+// Create the census node timeseries chart using data from the API and add it to the DOM.
+async function censusTimeSeriesChart() {
+        const data = await getCensusTimeSeriesData();
+        console.log(data);
+
+        if (data) {
+            document.getElementById('census-timeseries-graph').appendChild(createSquareChart(1700, 1700, data));
+        } else {
+            console.log('No data available to plot the census chart');
+        }
+}

--- a/glados-web/src/lib.rs
+++ b/glados-web/src/lib.rs
@@ -21,7 +21,7 @@ pub mod templates;
 
 use crate::state::State;
 
-const SOCKET: &str = "0.0.0.0:3001";
+const SOCKET: &str = "0.0.0.0:3002";
 
 const ASSET_PATH_ENV_VAR: &str = "GLADOS_WEB_ASSETS_PATH";
 
@@ -64,7 +64,8 @@ pub async fn run_glados_web(config: Arc<State>) -> Result<()> {
     let app = Router::new()
         .route("/", get(routes::root))
         .route("/census/census-list/", get(routes::census_explorer_list))
-        .route("/census/", get(routes::census_explorer))
+        .route("/census/", get(routes::single_census_view))
+        .route("/census/explorer", get(routes::census_explorer))
         .route("/network/", get(routes::network_dashboard))
         .route("/network/node/:node_id_hex/", get(routes::node_detail))
         .route(
@@ -95,7 +96,7 @@ pub async fn run_glados_web(config: Arc<State>) -> Result<()> {
         )
         .route("/api/stat-history/", get(routes::get_audit_stats_handler))
         .route(
-            "/api/census-node-timeseries/",
+            "/census/census-node-timeseries-data/",
             get(routes::census_timeseries),
         )
         .nest_service("/static/", serve_dir.clone())

--- a/glados-web/src/lib.rs
+++ b/glados-web/src/lib.rs
@@ -94,6 +94,10 @@ pub async fn run_glados_web(config: Arc<State>) -> Result<()> {
             get(routes::is_content_in_deadzone),
         )
         .route("/api/stat-history/", get(routes::get_audit_stats_handler))
+        .route(
+            "/api/census-node-timeseries/",
+            get(routes::census_timeseries),
+        )
         .nest_service("/static/", serve_dir.clone())
         .fallback_service(serve_dir)
         .layer(Extension(config));

--- a/glados-web/src/routes.rs
+++ b/glados-web/src/routes.rs
@@ -1188,10 +1188,7 @@ pub async fn census_timeseries(
 ) -> Result<Json<CensusTimeSeriesData>, StatusCode> {
     let days_ago: i32 = match http_args.get("days-ago") {
         None => 0,
-        Some(days_ago) => match days_ago.parse::<i32>() {
-            Ok(days_ago) => days_ago,
-            Err(_) => 0,
-        },
+        Some(days_ago) => days_ago.parse::<i32>().unwrap_or(0),
     };
 
     // Load all censuses in the given 24 hour window with each node's presence status & ENR
@@ -1270,12 +1267,14 @@ pub async fn census_timeseries(
 }
 
 /// Decouples census data from node data, now including ENR strings.
+type NodeIdString = String;
 fn decouple_nodes_and_censuses(
     node_statuses: Vec<NodeStatus>,
-) -> (Vec<String>, Vec<CensusStatuses>) {
+) -> (Vec<NodeIdString>, Vec<CensusStatuses>) {
     let mut node_set: HashSet<String> = HashSet::new();
-    let mut census_map: HashMap<i32, (DateTime<Utc>, HashMap<String, Option<i32>>)> =
-        HashMap::new();
+
+    type NodeEnrIdStatuses = HashMap<String, Option<i32>>;
+    let mut census_map: HashMap<i32, (DateTime<Utc>, NodeEnrIdStatuses)> = HashMap::new();
 
     for status in node_statuses {
         let hex_id = hex_encode(status.node_id);

--- a/glados-web/src/routes.rs
+++ b/glados-web/src/routes.rs
@@ -32,11 +32,11 @@ use tracing::error;
 use tracing::info;
 
 use crate::templates::{
-    AuditDashboardTemplate, AuditTableTemplate, CensusExplorerTemplate,
-    ContentAuditDetailTemplate, ContentDashboardTemplate, ContentIdDetailTemplate,
-    ContentIdListTemplate, ContentKeyDetailTemplate, ContentKeyListTemplate, EnrDetailTemplate,
-    HtmlTemplate, IndexTemplate, NetworkDashboardTemplate, NodeDetailTemplate,
-    SingleCensusViewTemplate, PaginatedCensusListTemplate,
+    AuditDashboardTemplate, AuditTableTemplate, CensusExplorerTemplate, ContentAuditDetailTemplate,
+    ContentDashboardTemplate, ContentIdDetailTemplate, ContentIdListTemplate,
+    ContentKeyDetailTemplate, ContentKeyListTemplate, EnrDetailTemplate, HtmlTemplate,
+    IndexTemplate, NetworkDashboardTemplate, NodeDetailTemplate, PaginatedCensusListTemplate,
+    SingleCensusViewTemplate,
 };
 use crate::{state::State, templates::AuditTuple};
 
@@ -1162,6 +1162,12 @@ pub struct NodeStatus {
     present: bool,
 }
 
+#[derive(Debug, Clone, FromQueryResult)]
+pub struct RecordInfo {
+    id: i32,
+    raw: String,
+}
+
 #[derive(Debug, Clone, Serialize)]
 pub struct CensusTimeSeriesData {
     node_ids: Vec<String>,
@@ -1173,14 +1179,13 @@ pub struct CensusTimeSeriesData {
 pub struct CensusStatuses {
     census_id: i32,
     time: DateTime<Utc>,
-    enr_statuses: Vec<Option<String>>,
+    enr_statuses: Vec<Option<i32>>,
 }
 
 pub async fn census_timeseries(
     http_args: HttpQuery<HashMap<String, String>>,
     Extension(state): Extension<Arc<State>>,
 ) -> Result<Json<CensusTimeSeriesData>, StatusCode> {
-
     let days_ago: i32 = match http_args.get("days-ago") {
         None => 0,
         Some(days_ago) => match days_ago.parse::<i32>() {
@@ -1189,6 +1194,7 @@ pub async fn census_timeseries(
         },
     };
 
+    // Load all censuses in the given 24 hour window with each node's presence status & ENR
     let node_statuses: Vec<NodeStatus> =
         NodeStatus::find_by_statement(Statement::from_sql_and_values(
             DbBackend::Postgres,
@@ -1203,7 +1209,7 @@ pub async fn census_timeseries(
                 END AS present
             FROM 
                 (
-                    SELECT * FROM census 
+                    SELECT * FROM census
                     WHERE started_at >= NOW() - INTERVAL '1 day' * ($1 + 1)
                     AND started_at < NOW() - INTERVAL '1 day' * $1
                 ) AS c
@@ -1224,22 +1230,58 @@ pub async fn census_timeseries(
             StatusCode::INTERNAL_SERVER_ERROR
         })?;
 
-    let census_node_timeseries: CensusTimeSeriesData = transform_data(node_statuses);
+    // Load all ENRs found in the census
+    let record_ids = node_statuses
+        .iter()
+        .map(|n| n.enr_id)
+        .collect::<HashSet<i32>>() // Collect into a HashSet to remove duplicates
+        .into_iter()
+        .collect::<Vec<i32>>();
+    let record_ids_str = format!(
+        "{{{}}}",
+        record_ids
+            .iter()
+            .map(|id| id.to_string())
+            .collect::<Vec<_>>()
+            .join(",")
+    );
+    let records: Vec<RecordInfo> = RecordInfo::find_by_statement(Statement::from_sql_and_values(
+        DbBackend::Postgres,
+        "SELECT id, raw
+            FROM record
+            WHERE id = ANY($1::int[]);",
+        vec![record_ids_str.into()],
+    ))
+    .all(&state.database_connection)
+    .await
+    .map_err(|e| {
+        error!(err=?e, "Failed to lookup census node timeseries data");
+        StatusCode::INTERNAL_SERVER_ERROR
+    })?;
+    let enr_id_map: HashMap<i32, String> = records.into_iter().map(|r| (r.id, r.raw)).collect();
 
-    Ok(Json(census_node_timeseries))
+    let (node_ids, censuses) = decouple_nodes_and_censuses(node_statuses);
+
+    Ok(Json(CensusTimeSeriesData {
+        node_ids,
+        censuses,
+        enrs: enr_id_map,
+    }))
 }
 
 /// Decouples census data from node data, now including ENR strings.
-fn transform_data(node_statuses: Vec<NodeStatus>) -> CensusTimeSeriesData {
+fn decouple_nodes_and_censuses(
+    node_statuses: Vec<NodeStatus>,
+) -> (Vec<String>, Vec<CensusStatuses>) {
     let mut node_set: HashSet<String> = HashSet::new();
-    let mut census_map: HashMap<i32, (DateTime<Utc>, HashMap<String, Option<String>>)> =
+    let mut census_map: HashMap<i32, (DateTime<Utc>, HashMap<String, Option<i32>>)> =
         HashMap::new();
 
     for status in node_statuses {
         let hex_id = hex_encode(status.node_id);
         node_set.insert(hex_id.clone());
         let enr_opt = if status.present {
-            Some(status.enr)
+            Some(status.enr_id)
         } else {
             None
         };
@@ -1267,23 +1309,7 @@ fn transform_data(node_statuses: Vec<NodeStatus>) -> CensusTimeSeriesData {
 
     censuses.sort_by_key(|c| c.time);
 
-    let enr_id_map: HashMap<i32, String> = node_statuses.into_iter().map(|n| n.enr_id).collect();
-
-    NodeStatus::find_by_statement(Statement::from_sql_and_values(
-        DbBackend::Postgres,
-        "SELECT id, raw
-        FROM Records
-        WHERE id = ANY(ARRAY[id_array]);",
-        
-    ))
-    .all(&state.database_connection)
-    .await
-    .map_err(|e| {
-        error!(err=?e, "Failed to lookup census node timeseries data");
-        StatusCode::INTERNAL_SERVER_ERROR
-    })?;
-
-    CensusTimeSeriesData { node_ids, censuses, enr_id_map }
+    (node_ids, censuses)
 }
 
 pub async fn single_census_view(
@@ -1328,4 +1354,3 @@ pub async fn single_census_view(
 
     Ok(HtmlTemplate(template))
 }
-

--- a/glados-web/src/routes.rs
+++ b/glados-web/src/routes.rs
@@ -17,14 +17,14 @@ use ethportal_api::utils::bytes::{hex_decode, hex_encode};
 use ethportal_api::{HistoryContentKey, OverlayContentKey};
 use glados_core::stats::{filter_audits, get_audit_stats, AuditFilters, Period};
 use migration::{Alias, JoinType, Order};
-use sea_orm::sea_query::SimpleExpr;
 use sea_orm::sea_query::{Expr, Query, SeaRc};
+use sea_orm::{sea_query::SimpleExpr, Statement};
 use sea_orm::{
     ColumnTrait, ConnectionTrait, DatabaseConnection, DbBackend, DynIden, EntityTrait,
     FromQueryResult, LoaderTrait, ModelTrait, PaginatorTrait, QueryFilter, QueryOrder, QuerySelect,
 };
 use serde::Serialize;
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::fmt::Formatter;
 use std::sync::Arc;
 use std::{fmt::Display, io};
@@ -1146,6 +1146,108 @@ pub async fn census_explorer_list(
     };
 
     Ok(HtmlTemplate(template))
+}
+
+#[derive(Debug, Clone, FromQueryResult)]
+pub struct NodeStatus {
+    enr: String,
+    census_time: DateTime<Utc>,
+    census_id: i32,
+    node_id: Vec<u8>,
+    present: bool,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct CensusTimeSeriesData {
+    node_ids: Vec<String>,
+    censuses: Vec<CensusStatuses>,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct CensusStatuses {
+    census_id: i32,
+    time: DateTime<Utc>,
+    enr_statuses: Vec<Option<String>>,
+}
+
+pub async fn census_timeseries(
+    Extension(state): Extension<Arc<State>>,
+) -> Result<Json<CensusTimeSeriesData>, StatusCode> {
+    let node_statuses: Vec<NodeStatus> =
+        NodeStatus::find_by_statement(Statement::from_sql_and_values(
+            DbBackend::Postgres,
+            "SELECT 
+                c.started_at AS census_time, 
+                c.id AS census_id,
+                n.node_id,
+                r.raw as enr,
+                CASE 
+                    WHEN r.id IS NOT NULL THEN true 
+                    ELSE false 
+                END AS present
+            FROM 
+                (SELECT * FROM census WHERE started_at >= NOW() - INTERVAL '1 day') AS c
+            LEFT JOIN 
+                census_node AS cn ON c.id = cn.census_id
+            LEFT JOIN 
+                record AS r ON r.id = cn.record_id
+            LEFT JOIN 
+                node AS n ON n.id = r.node_id
+            ORDER BY 
+                c.started_at, n.node_id;",
+            [],
+        ))
+        .all(&state.database_connection)
+        .await
+        .map_err(|e| {
+            error!(err=?e, "Failed to lookup census node timeseries data");
+            StatusCode::INTERNAL_SERVER_ERROR
+        })?;
+
+    let census_node_timeseries: CensusTimeSeriesData = transform_data(node_statuses);
+
+    Ok(Json(census_node_timeseries))
+}
+
+/// Decouples census data from node data, now including ENR strings.
+fn transform_data(node_statuses: Vec<NodeStatus>) -> CensusTimeSeriesData {
+    let mut node_set: HashSet<String> = HashSet::new();
+    let mut census_map: HashMap<i32, (DateTime<Utc>, HashMap<String, Option<String>>)> =
+        HashMap::new();
+
+    for status in node_statuses {
+        let hex_id = hex_encode(status.node_id);
+        node_set.insert(hex_id.clone());
+        let enr_opt = if status.present {
+            Some(status.enr)
+        } else {
+            None
+        };
+        let entry = census_map
+            .entry(status.census_id)
+            .or_insert((status.census_time, HashMap::new()));
+        entry.1.insert(hex_id, enr_opt);
+    }
+
+    let node_ids: Vec<String> = node_set.into_iter().collect();
+    let mut censuses: Vec<CensusStatuses> = vec![];
+
+    for (census_id, (time, enr_statuses_map)) in census_map {
+        let enr_statuses = node_ids
+            .iter()
+            .map(|node_id| enr_statuses_map.get(node_id).cloned().unwrap_or(None))
+            .collect();
+
+        censuses.push(CensusStatuses {
+            census_id,
+            time,
+            enr_statuses,
+        });
+    }
+
+    censuses.sort_by_key(|c| c.time);
+
+    CensusTimeSeriesData { node_ids, censuses }
 }
 
 pub async fn census_explorer(

--- a/glados-web/src/routes.rs
+++ b/glados-web/src/routes.rs
@@ -32,11 +32,11 @@ use tracing::error;
 use tracing::info;
 
 use crate::templates::{
-    AuditDashboardTemplate, AuditTableTemplate, CensusExplorerPageTemplate,
+    AuditDashboardTemplate, AuditTableTemplate, CensusExplorerTemplate,
     ContentAuditDetailTemplate, ContentDashboardTemplate, ContentIdDetailTemplate,
     ContentIdListTemplate, ContentKeyDetailTemplate, ContentKeyListTemplate, EnrDetailTemplate,
     HtmlTemplate, IndexTemplate, NetworkDashboardTemplate, NodeDetailTemplate,
-    PaginatedCensusListTemplate,
+    SingleCensusViewTemplate, PaginatedCensusListTemplate,
 };
 use crate::{state::State, templates::AuditTuple};
 
@@ -835,6 +835,11 @@ pub async fn contentaudit_dashboard() -> Result<HtmlTemplate<AuditDashboardTempl
     Ok(HtmlTemplate(template))
 }
 
+pub async fn census_explorer() -> Result<HtmlTemplate<CensusExplorerTemplate>, StatusCode> {
+    let template = CensusExplorerTemplate {};
+    Ok(HtmlTemplate(template))
+}
+
 /// Returns the success rate for the last hour as a percentage.
 pub async fn hourly_success_rate(
     Extension(state): Extension<Arc<State>>,
@@ -1150,7 +1155,7 @@ pub async fn census_explorer_list(
 
 #[derive(Debug, Clone, FromQueryResult)]
 pub struct NodeStatus {
-    enr: String,
+    enr_id: i32,
     census_time: DateTime<Utc>,
     census_id: i32,
     node_id: Vec<u8>,
@@ -1161,6 +1166,7 @@ pub struct NodeStatus {
 pub struct CensusTimeSeriesData {
     node_ids: Vec<String>,
     censuses: Vec<CensusStatuses>,
+    enrs: HashMap<i32, String>,
 }
 
 #[derive(Debug, Clone, Serialize)]
@@ -1171,8 +1177,18 @@ pub struct CensusStatuses {
 }
 
 pub async fn census_timeseries(
+    http_args: HttpQuery<HashMap<String, String>>,
     Extension(state): Extension<Arc<State>>,
 ) -> Result<Json<CensusTimeSeriesData>, StatusCode> {
+
+    let days_ago: i32 = match http_args.get("days-ago") {
+        None => 0,
+        Some(days_ago) => match days_ago.parse::<i32>() {
+            Ok(days_ago) => days_ago,
+            Err(_) => 0,
+        },
+    };
+
     let node_statuses: Vec<NodeStatus> =
         NodeStatus::find_by_statement(Statement::from_sql_and_values(
             DbBackend::Postgres,
@@ -1180,13 +1196,17 @@ pub async fn census_timeseries(
                 c.started_at AS census_time, 
                 c.id AS census_id,
                 n.node_id,
-                r.raw as enr,
+                r.id as enr_id,
                 CASE 
                     WHEN r.id IS NOT NULL THEN true 
                     ELSE false 
                 END AS present
             FROM 
-                (SELECT * FROM census WHERE started_at >= NOW() - INTERVAL '1 day') AS c
+                (
+                    SELECT * FROM census 
+                    WHERE started_at >= NOW() - INTERVAL '1 day' * ($1 + 1)
+                    AND started_at < NOW() - INTERVAL '1 day' * $1
+                ) AS c
             LEFT JOIN 
                 census_node AS cn ON c.id = cn.census_id
             LEFT JOIN 
@@ -1195,7 +1215,7 @@ pub async fn census_timeseries(
                 node AS n ON n.id = r.node_id
             ORDER BY 
                 c.started_at, n.node_id;",
-            [],
+            vec![days_ago.into()],
         ))
         .all(&state.database_connection)
         .await
@@ -1247,13 +1267,29 @@ fn transform_data(node_statuses: Vec<NodeStatus>) -> CensusTimeSeriesData {
 
     censuses.sort_by_key(|c| c.time);
 
-    CensusTimeSeriesData { node_ids, censuses }
+    let enr_id_map: HashMap<i32, String> = node_statuses.into_iter().map(|n| n.enr_id).collect();
+
+    NodeStatus::find_by_statement(Statement::from_sql_and_values(
+        DbBackend::Postgres,
+        "SELECT id, raw
+        FROM Records
+        WHERE id = ANY(ARRAY[id_array]);",
+        
+    ))
+    .all(&state.database_connection)
+    .await
+    .map_err(|e| {
+        error!(err=?e, "Failed to lookup census node timeseries data");
+        StatusCode::INTERNAL_SERVER_ERROR
+    })?;
+
+    CensusTimeSeriesData { node_ids, censuses, enr_id_map }
 }
 
-pub async fn census_explorer(
+pub async fn single_census_view(
     census_id: HttpQuery<HashMap<String, String>>,
     Extension(state): Extension<Arc<State>>,
-) -> Result<HtmlTemplate<CensusExplorerPageTemplate>, StatusCode> {
+) -> Result<HtmlTemplate<SingleCensusViewTemplate>, StatusCode> {
     let max_census_id = match get_max_census_id(&state).await {
         None => return Err(StatusCode::from_u16(404).unwrap()),
         Some(max_census_id) => max_census_id,
@@ -1278,7 +1314,7 @@ pub async fn census_explorer(
         Some(enr_list) => enr_list,
     };
 
-    let template = CensusExplorerPageTemplate {
+    let template = SingleCensusViewTemplate {
         client_diversity_data,
         node_count: enr_list.len() as i32,
         enr_list,
@@ -1292,3 +1328,4 @@ pub async fn census_explorer(
 
     Ok(HtmlTemplate(template))
 }
+

--- a/glados-web/src/templates.rs
+++ b/glados-web/src/templates.rs
@@ -27,8 +27,8 @@ pub struct PaginatedCensusListTemplate {
 }
 
 #[derive(Template)]
-#[template(path = "census_explorer_page.html")]
-pub struct CensusExplorerPageTemplate {
+#[template(path = "single_census_view.html")]
+pub struct SingleCensusViewTemplate {
     pub client_diversity_data: Vec<ClientDiversityResult>,
     pub enr_list: Vec<RawEnr>,
     pub census_id: i32,
@@ -36,6 +36,10 @@ pub struct CensusExplorerPageTemplate {
     pub node_count: i32,
     pub created_at: String,
 }
+
+#[derive(Template)]
+#[template(path = "census_explorer.html")]
+pub struct CensusExplorerTemplate {}
 
 #[derive(Template)]
 #[template(path = "network_dashboard.html")]

--- a/glados-web/templates/base.html
+++ b/glados-web/templates/base.html
@@ -40,7 +40,7 @@
                     </li>
                     <li class="nav-item">
                         <a class="nav-link active" aria-current="page" style="margin-left: 20px;"
-                           href="/census/?census-id=latest">Census Explorer</a>
+                           href="/census/explorer">Census Explorer</a>
                     </li>
                 </ul>
             </div>

--- a/glados-web/templates/census_explorer.html
+++ b/glados-web/templates/census_explorer.html
@@ -1,0 +1,31 @@
+{% extends "base.html" %}
+
+{% block title %}Glados{% endblock %}
+
+{% block head %}
+<script src="/static/js/d3.min.js"></script>
+<script src="/static/js/census-timeseries.js"></script>
+<script src="/static/js/trace/enr.js"></script>
+{% endblock %}
+
+{% block content %}
+<div class="container">
+    <div class="row">
+        <div class="col-lg-12 col-md-12 col-sm-12 margin-bottom">
+             <div id="census-timeseries-graph"> </div>
+        </div>
+        <br/>
+        <br/>
+        <br/>
+        <br/>
+        <br/>
+        <br/>
+        <br/>
+    </div>
+</div>
+
+<script>
+    censusTimeSeriesChart()
+</script>
+
+{% endblock %}

--- a/glados-web/templates/census_explorer.html
+++ b/glados-web/templates/census_explorer.html
@@ -12,20 +12,20 @@
 <div class="container">
     <div class="row">
         <div class="col-lg-12 col-md-12 col-sm-12 margin-bottom">
-             <div id="census-timeseries-graph"> </div>
+            <div id="census-timeseries-graph"> </div>
         </div>
-        <br/>
-        <br/>
-        <br/>
-        <br/>
-        <br/>
-        <br/>
-        <br/>
+        <br />
+        <br />
+        <br />
+        <br />
+        <br />
+        <br />
+        <br />
     </div>
 </div>
 
 <script>
-    censusTimeSeriesChart()
+    censusTimeSeriesChart(7)
 </script>
 
 {% endblock %}

--- a/glados-web/templates/census_explorer.html
+++ b/glados-web/templates/census_explorer.html
@@ -25,7 +25,7 @@
 </div>
 
 <script>
-    censusTimeSeriesChart(7)
+    censusTimeSeriesChart(0)
 </script>
 
 {% endblock %}

--- a/glados-web/templates/enr_detail.html
+++ b/glados-web/templates/enr_detail.html
@@ -69,10 +69,12 @@
                 throw new Error("Field not found.")
             }
             return field
+        } else if (key === "c") {
+            return value
         } else {
-            // default to assuming binary data
+            // default to assuming binary data            
             return toHexString(value)
-        }
+        } 
     }
 
     let {enr: decodedEnr, seq, signature} = ENR.ENR.decodeTxt("{{ enr.raw }}");

--- a/glados-web/templates/index.html
+++ b/glados-web/templates/index.html
@@ -8,6 +8,8 @@
 <script src="/static/js/trace/enr.js"></script>
 <script src="/static/js/radiusdensity.js"></script>
 <script src="/static/js/stats_history.js"></script>
+<script src="/static/js/census-timeseries.js"></script>
+<link href="/static/css/homepage.css" rel="stylesheet">
 {% endblock %}
 
 {% block content %}
@@ -75,10 +77,23 @@
         <div class="col-lg-7 col-md-12 col-sm-12 margin-bottom">
             <div class="card pie-box h-100">
                 <div class="card-body">
-                     <div id="stats-history-graph"> </div>
+                    <div id="stats-history-graph"> </div>
                 </div>
             </div>
         </div>
+    </div>
+    <div class="row">
+        <div class="col-lg-12 col-md-12 col-sm-12 margin-bottom">
+            <div id="census-timeseries-graph"> </div>
+            <br />
+            <br />
+            <br />
+            <br />
+            <br />
+            <br />
+        </div>
+        <br />
+        <br />
     </div>
 </div>
 
@@ -86,6 +101,7 @@
     pie_chart_count({{ client_diversity_data| json | safe }})
     radius_node_id_scatter_chart({{ average_radius_chart| json | safe }})
     statsHistoryChart()
+    censusTimeSeriesChart()
 
 </script>
 

--- a/glados-web/templates/index.html
+++ b/glados-web/templates/index.html
@@ -80,24 +80,8 @@
             </div>
         </div>
     </div>
-    <<<<<<< HEAD <div class="row">
-        <div class="col-lg-12 col-md-12 col-sm-12 margin-bottom">
-            <div id="census-timeseries-graph"> </div>
-            <br />
-            <br />
-            <br />
-            <br />
-            <br />
-            <br />
-        </div>
-        <br />
-        <br />
-</div>
-=======
 
->>>>>>> 362161f (feat: adds dedicated census explorer page)
 </div>
-
 <script>
     pie_chart_count({{ client_diversity_data| json | safe }})
     radius_node_id_scatter_chart({{ average_radius_chart| json | safe }})

--- a/glados-web/templates/index.html
+++ b/glados-web/templates/index.html
@@ -8,8 +8,6 @@
 <script src="/static/js/trace/enr.js"></script>
 <script src="/static/js/radiusdensity.js"></script>
 <script src="/static/js/stats_history.js"></script>
-<script src="/static/js/census-timeseries.js"></script>
-<link href="/static/css/homepage.css" rel="stylesheet">
 {% endblock %}
 
 {% block content %}
@@ -82,7 +80,7 @@
             </div>
         </div>
     </div>
-    <div class="row">
+    <<<<<<< HEAD <div class="row">
         <div class="col-lg-12 col-md-12 col-sm-12 margin-bottom">
             <div id="census-timeseries-graph"> </div>
             <br />
@@ -94,14 +92,16 @@
         </div>
         <br />
         <br />
-    </div>
+</div>
+=======
+
+>>>>>>> 362161f (feat: adds dedicated census explorer page)
 </div>
 
 <script>
     pie_chart_count({{ client_diversity_data| json | safe }})
     radius_node_id_scatter_chart({{ average_radius_chart| json | safe }})
     statsHistoryChart()
-    censusTimeSeriesChart()
 
 </script>
 

--- a/glados-web/templates/single_census_view.html
+++ b/glados-web/templates/single_census_view.html
@@ -6,7 +6,6 @@
 <script src="/static/js/d3.min.js"></script>
 <script src="/static/js/piechart.js"></script>
 <script src="/static/js/radiusdensity.js"></script>
-<link href="/static/css/homepage.css" rel="stylesheet">
 {% endblock %}
 
 {% block content %}
@@ -20,14 +19,18 @@
                         <div class="col-xl-5 col-lg-6 col-md-12">
                             <table class="table table-borderless">
                                 <tbody>
-                                <tr>
-                                    <td>Created At</td>
-                                    <td><p class="text-end">{{ created_at }}</p></td>
-                                </tr>
-                                <tr>
-                                    <td>Number of Nodes</td>
-                                    <td><p class="text-end">{{ node_count }}</p></td>
-                                </tr>
+                                    <tr>
+                                        <td>Created At</td>
+                                        <td>
+                                            <p class="text-end">{{ created_at }}</p>
+                                        </td>
+                                    </tr>
+                                    <tr>
+                                        <td>Number of Nodes</td>
+                                        <td>
+                                            <p class="text-end">{{ node_count }}</p>
+                                        </td>
+                                    </tr>
                                 </tbody>
                             </table>
                         </div>
@@ -36,27 +39,36 @@
                                 <nav aria-label="census explorer navigation">
                                     <ul class="pagination justify-content-center">
                                         <li class="page-item {% if census_id == 1 %}disabled{% endif %}">
-                                            <a class="page-link" href="/census/?census-id={{ census_id - 1}}">Previous</a>
+                                            <a class="page-link"
+                                                href="/census/?census-id={{ census_id - 1}}">Previous</a>
                                         </li>
-                                        <li class="page-item {% if census_id == 1 %}active{% endif -%}"><a class="page-link" href="/census/1">1</a></li>
+                                        <li class="page-item {% if census_id == 1 %}active{% endif -%}"><a
+                                                class="page-link" href="/census/1">1</a></li>
                                         {% if max_census_id != 1 %}
-                                        <li class="page-item {% if census_id != 1 && census_id != max_census_id %}active{% endif %}">
+                                        <li
+                                            class="page-item {% if census_id != 1 && census_id != max_census_id %}active{% endif %}">
                                             {% if census_id == 1 %}
-                                            <a class="page-link" href="/census/?census-id={{ census_id + 1 }}">{{ census_id + 1 }}</a>
+                                            <a class="page-link" href="/census/?census-id={{ census_id + 1 }}">{{
+                                                census_id + 1 }}</a>
                                             {% else if census_id == max_census_id %}
-                                            <a class="page-link" href="/census/?census-id={{ census_id - 1 }}">{{ census_id - 1 }}</a>
+                                            <a class="page-link" href="/census/?census-id={{ census_id - 1 }}">{{
+                                                census_id - 1 }}</a>
                                             {% else %}
-                                            <a class="page-link" href="/census/?census-id={{ census_id }}">{{ census_id }}</a>
+                                            <a class="page-link" href="/census/?census-id={{ census_id }}">{{ census_id
+                                                }}</a>
                                             {% endif %}
                                         </li>
-                                        <li class="page-item {% if census_id == max_census_id %}active{% endif %}"><a class="page-link" href="/census/?census-id={{ max_census_id }}">{{ max_census_id }}</a></li>
+                                        <li class="page-item {% if census_id == max_census_id %}active{% endif %}"><a
+                                                class="page-link" href="/census/?census-id={{ max_census_id }}">{{
+                                                max_census_id }}</a></li>
                                         {% endif %}
                                         <li class="page-item {% if census_id == max_census_id %}disabled{% endif %}">
                                             <a class="page-link" href="/census/?census-id={{ census_id + 1 }}">Next</a>
                                         </li>
                                     </ul>
                                 </nav>
-                                <a href="/census/census-list/?page=1" class="btn btn-outline-secondary" type="button">List of all past census's</a>
+                                <a href="/census/census-list/?page=1" class="btn btn-outline-secondary"
+                                    type="button">List of all past census's</a>
                             </div>
                         </div>
                     </div>
@@ -78,16 +90,16 @@
                     <div class="table-responsive">
                         <table class="table">
                             <thead>
-                            <tr>
-                                <th scope="col">ENR</th>
-                            </tr>
+                                <tr>
+                                    <th scope="col">ENR</th>
+                                </tr>
                             </thead>
                             <tbody>
-                            {% for enr in enr_list %}
-                            <tr>
-                                <td>{{ enr.raw }}</td>
-                            </tr>
-                            {% endfor %}
+                                {% for enr in enr_list %}
+                                <tr>
+                                    <td>{{ enr.raw }}</td>
+                                </tr>
+                                {% endfor %}
                             </tbody>
                         </table>
                     </div>


### PR DESCRIPTION
**What was the problem?**

Census data was only visible at specific moments of time, rather than over any period of time. 

**How was it fixed?**

The census explorer page shows all nodes seen in the last 24 hours and their census status at each census over that period. 

Nodes are sorted by client string, and then by node ID. Unhighlighted Node IDs on the left axis are meant to be more searchable (Cmd F) than readable. 

![Screen Shot 2024-03-11 at 5 56 09 PM](https://github.com/ethereum/glados/assets/4079737/cd7cd4cb-d2b0-4e4c-9b48-89e0fd961d78)

- [x] Efficient scrolling
- [x] Pagination

Subsequent PRs will:
- show errors logged during census
- label trin testnet nodes (eg trin-ams-10)

Implements #200


