### PR TITLE
fix: disable poke for trin docker compose

### DIFF
--- a/docker-compose-clients.yml
+++ b/docker-compose-clients.yml
@@ -3,7 +3,7 @@ services:
     image: portalnetwork/trin:latest
     environment:
       RUST_LOG: info
-    command: "--web3-transport http --web3-http-address http://0.0.0.0:8545/ --mb 0 --no-upnp"
+    command: "--web3-transport http --web3-http-address http://0.0.0.0:8545/ --mb 0 --no-upnp --disable-poke"
 
   fluffy:
     image: statusim/nimbus-fluffy:amd64-master-latest


### PR DESCRIPTION
disable poke was added to trin 3 months ago but we forgot to disable it on glados.

![image](https://github.com/ethereum/glados/assets/31669092/30591826-1ab9-48d9-b608-d4b1a9c8524b)
It is crazy how much traffic poke was generating from glados