### PR TITLE
feat: adds fourfours strategy to glados-audit

### DIFF
--- a/entity/src/audit_stats.rs
+++ b/entity/src/audit_stats.rs
@@ -16,6 +16,7 @@ pub struct Model {
     pub success_rate_latest: f32,
     pub success_rate_random: f32,
     pub success_rate_oldest: f32,
+    pub success_rate_four_fours: f32,
     pub success_rate_all_headers: f32,
     pub success_rate_all_bodies: f32,
     pub success_rate_all_receipts: f32,
@@ -25,6 +26,9 @@ pub struct Model {
     pub success_rate_random_headers: f32,
     pub success_rate_random_bodies: f32,
     pub success_rate_random_receipts: f32,
+    pub success_rate_four_fours_headers: f32,
+    pub success_rate_four_fours_bodies: f32,
+    pub success_rate_four_fours_receipts: f32,
 }
 
 #[derive(Copy, Clone, Debug, EnumIter, DeriveRelation)]
@@ -40,6 +44,7 @@ pub async fn create(
     success_rate_latest: f32,
     success_rate_random: f32,
     success_rate_oldest: f32,
+    success_rate_four_fours: f32,
     success_rate_all_headers: f32,
     success_rate_all_bodies: f32,
     success_rate_all_receipts: f32,
@@ -49,6 +54,9 @@ pub async fn create(
     success_rate_random_headers: f32,
     success_rate_random_bodies: f32,
     success_rate_random_receipts: f32,
+    success_rate_four_fours_headers: f32,
+    success_rate_four_fours_bodies: f32,
+    success_rate_four_fours_receipts: f32,
     conn: &DatabaseConnection,
 ) -> Result<Model> {
     let audit_stats = ActiveModel {
@@ -59,6 +67,7 @@ pub async fn create(
         success_rate_latest: Set(success_rate_latest),
         success_rate_random: Set(success_rate_random),
         success_rate_oldest: Set(success_rate_oldest),
+        success_rate_four_fours: Set(success_rate_four_fours),
         success_rate_all_headers: Set(success_rate_all_headers),
         success_rate_all_bodies: Set(success_rate_all_bodies),
         success_rate_all_receipts: Set(success_rate_all_receipts),
@@ -68,6 +77,9 @@ pub async fn create(
         success_rate_random_headers: Set(success_rate_random_headers),
         success_rate_random_bodies: Set(success_rate_random_bodies),
         success_rate_random_receipts: Set(success_rate_random_receipts),
+        success_rate_four_fours_headers: Set(success_rate_four_fours_headers),
+        success_rate_four_fours_bodies: Set(success_rate_four_fours_bodies),
+        success_rate_four_fours_receipts: Set(success_rate_four_fours_receipts),
     };
     Ok(audit_stats.insert(conn).await?)
 }

--- a/entity/src/content_audit.rs
+++ b/entity/src/content_audit.rs
@@ -37,6 +37,8 @@ pub enum SelectionStrategy {
     SelectOldestUnaudited = 3,
     /// Perform a single audit for a previously audited content key.
     SpecificContentKey = 4,
+    /// Perform audits of random fourfours data.
+    FourFours = 5,
 }
 
 impl AuditResult {
@@ -157,6 +159,7 @@ impl SelectionStrategy {
             SelectionStrategy::Latest => "Latest".to_string(),
             SelectionStrategy::Random => "Random".to_string(),
             SelectionStrategy::Failed => "Failed".to_string(),
+            SelectionStrategy::FourFours => "FourFours".to_string(),
             SelectionStrategy::SelectOldestUnaudited => "Select Oldest Unaudited".to_string(),
             SelectionStrategy::SpecificContentKey => "Specific Content Key".to_string(),
         }

--- a/glados-audit/Cargo.toml
+++ b/glados-audit/Cargo.toml
@@ -15,6 +15,7 @@ clap = { version = "4.0.24", features = ["derive"] }
 entity = { path = "../entity" }
 env_logger = "0.9.3"
 ethereum-types = "0.14.0"
+web3 = "0.18.0"
 ethportal-api = "0.2.2"
 glados-core = { path = "../glados-core" }
 migration = { path = "../migration" }
@@ -24,5 +25,3 @@ serde_json = "1.0.95"
 tokio = "1.21.2"
 tracing = "0.1.37"
 url = "2.3.1"
-web3 = "0.18.0"
-

--- a/glados-audit/src/cli.rs
+++ b/glados-audit/src/cli.rs
@@ -9,6 +9,13 @@ const DEFAULT_STATS_PERIOD: &str = "300";
 pub struct Args {
     #[arg(short, long, default_value = DEFAULT_DB_URL)]
     pub database_url: String,
+    #[arg(
+        short,
+        long,
+        default_value = "",
+        help = "web3 api provider url, eg https://mainnet.infura.io/v3/..."
+    )]
+    pub provider_url: String,
     #[arg(short, long, default_value = "4", help = "number of auditing threads")]
     pub concurrency: u8,
     #[arg(short, long, action(ArgAction::Append), value_enum, default_value = None, help = "Specific strategy to use. Default is to use all available strategies. May be passed multiple times for multiple strategies (--strategy latest --strategy random). Duplicates are permitted (--strategy random --strategy random).")]
@@ -41,9 +48,15 @@ pub struct Args {
         help = "relative weight of the 'random' strategy"
     )]
     pub random_strategy_weight: u8,
+    #[arg(
+        long,
+        default_value = "1",
+        help = "relative weight of the 'four_fours' strategy"
+    )]
+    pub four_fours_strategy_weight: u8,
     #[arg(long, default_value = DEFAULT_STATS_PERIOD, help = "stats recording period (seconds)")]
     pub stats_recording_period: u64,
-    #[arg(short, long, action(ArgAction::Append))]
+    #[arg(long, action(ArgAction::Append))]
     pub portal_client: Vec<String>,
     #[command(subcommand)]
     pub subcommand: Option<Command>,
@@ -63,11 +76,13 @@ impl Default for Args {
     fn default() -> Self {
         Self {
             database_url: DEFAULT_DB_URL.to_string(),
+            provider_url: "".to_string(),
             concurrency: 4,
             latest_strategy_weight: 1,
             failed_strategy_weight: 1,
             oldest_strategy_weight: 1,
             random_strategy_weight: 1,
+            four_fours_strategy_weight: 1,
             strategy: None,
             portal_client: vec!["ipc:////tmp/trin-jsonrpc.ipc".to_owned()],
             subcommand: None,
@@ -157,6 +172,26 @@ mod test {
                 SelectionStrategy::Latest,
                 SelectionStrategy::Random,
             ]),
+            portal_client: vec![PORTAL_CLIENT_STRING.to_owned()],
+            ..Default::default()
+        };
+        assert_eq!(result, expected);
+    }
+
+    /// Tests that the provider_url is passed through properly.
+    #[test]
+    fn test_provider_url() {
+        const PORTAL_CLIENT_STRING: &str = "ipc:////path/to/ipc";
+        const PROVIDER_URL: &str = "https://example.io/key";
+        let result = Args::parse_from([
+            "test",
+            "--provider-url",
+            PROVIDER_URL,
+            "--portal-client",
+            PORTAL_CLIENT_STRING,
+        ]);
+        let expected = Args {
+            provider_url: PROVIDER_URL.to_string(),
             portal_client: vec![PORTAL_CLIENT_STRING.to_owned()],
             ..Default::default()
         };

--- a/glados-core/src/db.rs
+++ b/glados-core/src/db.rs
@@ -1,0 +1,98 @@
+use anyhow::Error;
+use entity::{content, execution_metadata};
+use ethportal_api::{
+    utils::bytes::hex_encode, BlockBodyKey, BlockHeaderKey, BlockReceiptsKey, HistoryContentKey,
+    OverlayContentKey,
+};
+use sea_orm::DatabaseConnection;
+use tracing::{debug, error};
+
+/// Stores the content keys and block metadata for the given block.
+///
+/// The metadata included is the block number and hash under the execution
+/// header, body and receipts tables.
+///
+/// Errors are logged.
+pub async fn store_block_keys(
+    block_number: i32,
+    block_hash: &[u8; 32],
+    conn: &DatabaseConnection,
+) -> Vec<content::Model> {
+    let header = HistoryContentKey::BlockHeaderWithProof(BlockHeaderKey {
+        block_hash: *block_hash,
+    });
+    let body = HistoryContentKey::BlockBody(BlockBodyKey {
+        block_hash: *block_hash,
+    });
+    let receipts = HistoryContentKey::BlockReceipts(BlockReceiptsKey {
+        block_hash: *block_hash,
+    });
+
+    let header = store_content_key(&header, "block_header", block_number, conn).await;
+    let body = store_content_key(&body, "block_body", block_number, conn).await;
+    let receipts = store_content_key(&receipts, "block_receipts", block_number, conn).await;
+
+    let mut returned_values = vec![];
+    if let Some(header) = header {
+        returned_values.push(header);
+    }
+    if let Some(body) = body {
+        returned_values.push(body);
+    }
+    if let Some(receipts) = receipts {
+        returned_values.push(receipts);
+    }
+    returned_values
+}
+
+/// Accepts a ContentKey from the History and attempts to store it.
+///
+/// Errors are logged.
+pub async fn store_content_key<T: OverlayContentKey>(
+    key: &T,
+    name: &str,
+    block_number: i32,
+    conn: &DatabaseConnection,
+) -> Option<content::Model> {
+    // Store key
+    match content::get_or_create(key, conn).await {
+        Ok(content_model) => {
+            log_record_outcome(key, name, DbOutcome::Success);
+            // Store metadata
+            let metadata_str = format!("{name}_metadata");
+            match execution_metadata::get_or_create(content_model.id, block_number, conn).await {
+                Ok(_) => log_record_outcome(key, metadata_str.as_str(), DbOutcome::Success),
+                Err(e) => log_record_outcome(key, metadata_str.as_str(), DbOutcome::Fail(e)),
+            };
+            Some(content_model)
+        }
+        Err(e) => {
+            log_record_outcome(key, name, DbOutcome::Fail(e));
+            None
+        }
+    }
+}
+
+/// Logs a database record error for the given key.
+///
+/// Helper function for common error pattern to be logged.
+pub fn log_record_outcome<T: OverlayContentKey>(key: &T, name: &str, outcome: DbOutcome) {
+    match outcome {
+        DbOutcome::Success => debug!(
+            content.key = hex_encode(key.to_bytes()),
+            content.kind = name,
+            "Imported new record",
+        ),
+        DbOutcome::Fail(e) => error!(
+            content.key=hex_encode(key.to_bytes()),
+            content.kind=name,
+            err=?e,
+            "Failed to create database record",
+        ),
+    }
+}
+
+pub enum DbOutcome {
+    Success,
+    Fail(Error),
+}

--- a/glados-core/src/lib.rs
+++ b/glados-core/src/lib.rs
@@ -1,2 +1,3 @@
+pub mod db;
 pub mod jsonrpc;
 pub mod stats;

--- a/glados-core/src/stats.rs
+++ b/glados-core/src/stats.rs
@@ -31,6 +31,9 @@ pub fn filter_audits(filters: AuditFilters) -> Select<content_audit::Entity> {
         StrategyFilter::Oldest => audits.filter(
             content_audit::Column::StrategyUsed.eq(SelectionStrategy::SelectOldestUnaudited),
         ),
+        StrategyFilter::FourFours => {
+            audits.filter(content_audit::Column::StrategyUsed.eq(SelectionStrategy::FourFours))
+        }
     };
     // Success filters
     let audits = match filters.success {
@@ -200,6 +203,7 @@ pub enum StrategyFilter {
     Random,
     Latest,
     Oldest,
+    FourFours,
 }
 
 #[derive(Deserialize)]

--- a/glados-web/assets/js/stats_history.js
+++ b/glados-web/assets/js/stats_history.js
@@ -98,9 +98,10 @@ function createMultiLineChart(height, width, dataSets) {
     }
 
     // Select all '.legend' group elements and click on all but the first three
+    let selectedIndexes = [0, 4, 14, 15, 16]
     svg.selectAll(".legend")
-        .each(function(d, i) {
-            if (i >= 3) { // Skip the first three
+        .each(function (d, i) {
+            if (!selectedIndexes.includes(i)) {
                 dispatchClick(this);
             }
         });
@@ -113,7 +114,11 @@ function createMultiLineChart(height, width, dataSets) {
         .attr("fill", (d, i) => colors[i % colors.length]);
 
     // Add text to the legend.
-    const labels = ["All", "Latest", "Random", "Oldest", "All Headers", "All Bodies", "All Receipts", "Latest Headers", "Latest Bodies", "Latest Receipts", "Random Headers", "Random Bodies", "Random Receipts"];
+    const labels = ["All", "Latest", "Random", "Oldest", "4444s",
+        "All Headers", "All Bodies", "All Receipts",
+        "Latest Headers", "Latest Bodies", "Latest Receipts",
+        "Random Headers", "Random Bodies", "Random Receipts",
+        "4444s Headers", "4444s Bodies", "4444s Receipts"];
     legend.append("text")
         .attr("x", -24)
         .attr("y", 9)
@@ -131,6 +136,7 @@ function convertDataForChart(data) {
         'success_rate_latest',
         'success_rate_random',
         'success_rate_oldest',
+        'success_rate_four_fours',
         'success_rate_all_headers',
         'success_rate_all_bodies',
         'success_rate_all_receipts',
@@ -140,6 +146,9 @@ function convertDataForChart(data) {
         'success_rate_random_headers',
         'success_rate_random_bodies',
         'success_rate_random_receipts',
+        'success_rate_four_fours_headers',
+        'success_rate_four_fours_bodies',
+        'success_rate_four_fours_receipts'
     ];
 
     return successRateKeys.map(key =>

--- a/glados-web/templates/audit_dashboard.html
+++ b/glados-web/templates/audit_dashboard.html
@@ -29,6 +29,8 @@
                     type="button">Random</button>
                 <button id="oldest-button" filter="Oldest" class="btn btn-outline-secondary" type="button">Oldest
                     Unaudited</button>
+                <button id="fourfours-button" filter="FourFours" class="btn btn-outline-secondary"
+                    type="button">4444s</button>
             </div>
             <div id="success-buttons" class="btn-group mx-1 " role="group">
                 <button id="all-success-button" filter="All" class="btn btn-outline-secondary"
@@ -41,7 +43,7 @@
         </div>
     </div>
 </div>
-<br/>
+<br />
 <div id="audit-table"></div>
 <style>
     .btn-outline-secondary.active {

--- a/migration/src/lib.rs
+++ b/migration/src/lib.rs
@@ -9,6 +9,7 @@ mod m20230511_104830_create_content_audit;
 mod m20230511_104838_create_execution_metadata;
 mod m20230511_104937_create_key_value;
 mod m20231107_004843_create_audit_stats;
+mod m20240213_190221_add_fourfours_stats;
 
 pub struct Migrator;
 
@@ -25,6 +26,7 @@ impl MigratorTrait for Migrator {
             Box::new(m20230511_104937_create_key_value::Migration),
             Box::new(m20230508_111707_create_census_tables::Migration),
             Box::new(m20231107_004843_create_audit_stats::Migration),
+            Box::new(m20240213_190221_add_fourfours_stats::Migration),
         ]
     }
 }

--- a/migration/src/m20240213_190221_add_fourfours_stats.rs
+++ b/migration/src/m20240213_190221_add_fourfours_stats.rs
@@ -1,0 +1,60 @@
+use sea_orm_migration::prelude::*;
+
+#[derive(DeriveMigrationName)]
+pub struct Migration;
+
+#[async_trait::async_trait]
+impl MigrationTrait for Migration {
+    async fn up(&self, manager: &SchemaManager) -> Result<(), DbErr> {
+        manager
+            .alter_table(
+                Table::alter()
+                    .table(AuditStats::Table)
+                    .add_column_if_not_exists(
+                        ColumnDef::new(AuditStats::SuccessRateFourFours)
+                            .float()
+                            .default(0.0),
+                    )
+                    .add_column_if_not_exists(
+                        ColumnDef::new(AuditStats::SuccessRateFourFoursHeaders)
+                            .float()
+                            .default(0.0),
+                    )
+                    .add_column_if_not_exists(
+                        ColumnDef::new(AuditStats::SuccessRateFourFoursBodies)
+                            .float()
+                            .default(0.0),
+                    )
+                    .add_column_if_not_exists(
+                        ColumnDef::new(AuditStats::SuccessRateFourFoursReceipts)
+                            .float()
+                            .default(0.0),
+                    )
+                    .to_owned(),
+            )
+            .await
+    }
+
+    async fn down(&self, manager: &SchemaManager) -> Result<(), DbErr> {
+        manager
+            .alter_table(
+                Table::alter()
+                    .table(AuditStats::Table)
+                    .drop_column(AuditStats::SuccessRateFourFours)
+                    .drop_column(AuditStats::SuccessRateFourFoursHeaders)
+                    .drop_column(AuditStats::SuccessRateFourFoursBodies)
+                    .drop_column(AuditStats::SuccessRateFourFoursReceipts)
+                    .to_owned(),
+            )
+            .await
+    }
+}
+
+#[derive(Iden)]
+enum AuditStats {
+    Table,
+    SuccessRateFourFours,
+    SuccessRateFourFoursHeaders,
+    SuccessRateFourFoursBodies,
+    SuccessRateFourFoursReceipts,
+}


### PR DESCRIPTION
**What's the problem?**
The approach to 4444s stats taken in #230 requires pre-loading the DB with all 45mil+ content keys. This is quite an operational overhead. 

**What's the solution?**
This PR adds a dedicated `FourFours` audit strategy that has access to a `Web3` provider that it uses to randomly select  hashes for blocks between genesis and merge, stores their content keys in the DB, and then audits them. 

It also adds 4444s statistics to the front page, and the filtering option to the Audit Dashboard. 