### PR TITLE
feat: expects error for content not found

### DIFF
--- a/glados-audit/src/lib.rs
+++ b/glados-audit/src/lib.rs
@@ -1,3 +1,8 @@
+use anyhow::Result;
+use cli::Args;
+use ethportal_api::utils::bytes::{hex_decode, hex_encode};
+use ethportal_api::{HistoryContentKey, OverlayContentKey};
+use sea_orm::DatabaseConnection;
 use std::{
     collections::HashMap,
     sync::{
@@ -6,12 +11,6 @@ use std::{
     },
     thread::available_parallelism,
 };
-
-use anyhow::Result;
-use cli::Args;
-use ethportal_api::utils::bytes::{hex_decode, hex_encode};
-use ethportal_api::{HistoryContentKey, OverlayContentKey};
-use sea_orm::DatabaseConnection;
 use tokio::{
     sync::mpsc::{self, Receiver},
     time::{sleep, Duration},


### PR DESCRIPTION
**What was wrong?**

Portal specs now define an error that's returned when content isn't successfully retrieved. Glados was expecting the previous `0x` value for data that isn't found.

**How was it fixed?**

A custom `From<jsonrpsee::Error> for JsonRpcError` implementation that checks the error code and creates a `ContentNotFound` error if applicable, otherwise falls back to the original `jsonrpsee::Error`.