### PR TITLE
fix: add provider url to audit in compose

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -24,7 +24,7 @@ services:
     restart: always
 
   glados_audit:
-    command: "--database-url postgres://postgres:${GLADOS_POSTGRES_PASSWORD}@glados_postgres:5432/glados --portal-client http://host.docker.internal:8545 --concurrency 8 --latest-strategy-weight 2"
+    command: "--database-url postgres://postgres:${GLADOS_POSTGRES_PASSWORD}@glados_postgres:5432/glados --portal-client http://host.docker.internal:8545 --concurrency 8 --latest-strategy-weight 2 --provider-url ${GLADOS_PROVIDER_URL?Provider URL required}""
     image: portalnetwork/glados-audit:latest
     environment:
       RUST_LOG: warn,glados_audit=info


### PR DESCRIPTION
**What was wrong?**

Previous PR gave `glados-audit` access to a block provider, `docker-compose.yml` doesn't pass this flag in