### PR TITLE
fix: update stats history to default to latest and 4444s

### DIFF
--- a/glados-web/assets/js/stats_history.js
+++ b/glados-web/assets/js/stats_history.js
@@ -98,7 +98,7 @@ function createMultiLineChart(height, width, dataSets) {
     }
 
     // Select all '.legend' group elements and click on all but the first three
-    let selectedIndexes = [0, 4, 14, 15, 16]
+    let selectedIndexes = [1, 4]
     svg.selectAll(".legend")
         .each(function (d, i) {
             if (!selectedIndexes.includes(i)) {


### PR DESCRIPTION
> feature request can we have latest & 4444s be the only default lines that show up on the dashboard graph? it's a bit crowded
- @njgheorghita 
