### PR TITLE
fix: inaccurate content key timestamps

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2333,6 +2333,7 @@ name = "glados-monitor"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "chrono",
  "clap 4.5.3",
  "entity",
  "env_logger 0.9.3",

--- a/entity/src/content.rs
+++ b/entity/src/content.rs
@@ -62,6 +62,7 @@ impl ActiveModelBehavior for ActiveModel {}
 
 pub async fn get_or_create<T: OverlayContentKey>(
     content_key: &T,
+    available_at: DateTime<Utc>,
     conn: &DatabaseConnection,
 ) -> Result<Model> {
     // First try to lookup an existing entry.
@@ -80,7 +81,7 @@ pub async fn get_or_create<T: OverlayContentKey>(
         content_id: Set(content_key.content_id().to_vec()),
         content_key: Set(content_key.to_bytes()),
         protocol_id: Set(SubProtocol::History),
-        first_available_at: Set(Utc::now()),
+        first_available_at: Set(available_at),
     };
     Ok(content_key.insert(conn).await?)
 }

--- a/entity/src/test.rs
+++ b/entity/src/test.rs
@@ -128,7 +128,9 @@ async fn test_content_id_as_hash() -> Result<(), DbErr> {
     let conn = setup_database().await?;
     let key = sample_history_key();
     let content_id_hash = H256::from_slice(&key.content_id());
-    let content_model = content::get_or_create(&key, &conn).await.unwrap();
+    let content_model = content::get_or_create(&key, Utc::now(), &conn)
+        .await
+        .unwrap();
     assert_eq!(content_model.id_as_hash(), content_id_hash);
     Ok(())
 }
@@ -140,7 +142,9 @@ async fn test_content_id_as_hex() -> Result<(), DbErr> {
     let key = sample_history_key();
     let content_id_hash = H256::from_slice(&key.content_id());
     let content_id_hex = hex_encode(content_id_hash);
-    let content_model = content::get_or_create(&key, &conn).await.unwrap();
+    let content_model = content::get_or_create(&key, Utc::now(), &conn)
+        .await
+        .unwrap();
     assert_eq!(content_model.id_as_hex(), content_id_hex);
     Ok(())
 }
@@ -150,7 +154,9 @@ async fn test_content_id_as_hex() -> Result<(), DbErr> {
 async fn test_content_key_as_hex() -> Result<(), DbErr> {
     let conn = setup_database().await?;
     let key = sample_history_key();
-    let content_model = content::get_or_create(&key, &conn).await.unwrap();
+    let content_model = content::get_or_create(&key, Utc::now(), &conn)
+        .await
+        .unwrap();
     assert_eq!(
         content_model.key_as_hex(),
         "0x00000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f"
@@ -168,13 +174,17 @@ async fn test_content_get_or_create() -> Result<(), DbErr> {
     // Ensure our database is empty
     assert_eq!(content::Entity::find().count(&conn).await?, 0);
 
-    let content_id_a = content::get_or_create(&key, &conn).await.unwrap();
+    let content_id_a = content::get_or_create(&key, Utc::now(), &conn)
+        .await
+        .unwrap();
 
     // Ensure we added a new record to the database.
     assert_eq!(content::Entity::find().count(&conn).await?, 1);
 
     // Retrieve the key
-    let content_id_b = content::get_or_create(&key, &conn).await.unwrap();
+    let content_id_b = content::get_or_create(&key, Utc::now(), &conn)
+        .await
+        .unwrap();
 
     // Key was not saved twice.
     assert_eq!(content::Entity::find().count(&conn).await?, 1);

--- a/glados-monitor/Cargo.toml
+++ b/glados-monitor/Cargo.toml
@@ -12,6 +12,7 @@ authors = ["Piper Merriam <piper@pipermerriam.com>"]
 anyhow = "1.0.68"
 glados-core = { path = "../glados-core" }
 migration = { path = "../migration" }
+chrono = "0.4.22"
 entity = { path = "../entity" }
 clap = { version = "4.0.24", features = ["derive"] }
 web3 = "0.18.0"

--- a/glados-monitor/src/lib.rs
+++ b/glados-monitor/src/lib.rs
@@ -2,6 +2,7 @@ use std::path::PathBuf;
 use std::time::Duration;
 
 use anyhow::{anyhow, Result};
+use chrono::Utc;
 use ethereum_types::H256;
 use ethportal_api::utils::bytes::hex_decode;
 use ethportal_api::{EpochAccumulatorKey, HistoryContentKey};
@@ -109,7 +110,7 @@ async fn retrieve_new_blocks(
 
         let block_num =
             i32::try_from(block_number_to_retrieve).expect("Block num does not fit in i32.");
-        store_block_keys(block_num, block_hash.as_fixed_bytes(), &conn).await;
+        store_block_keys(block_num, block_hash.as_fixed_bytes(), Utc::now(), &conn).await;
     }
 }
 
@@ -169,7 +170,7 @@ pub async fn import_pre_merge_accumulators(
                                     });
                                 debug!(content_key = %content_key, "Importing");
                                 let content_key_db =
-                                    content::get_or_create(&content_key, &conn).await?;
+                                    content::get_or_create(&content_key, Utc::now(), &conn).await?;
                                 info!(content_key = %content_key, database_id = content_key_db.id, "Imported");
                             }
                             Err(_) => info!(
@@ -242,7 +243,8 @@ pub async fn bulk_download_block_data(
 
                 let block_number =
                     i32::try_from(block_number).expect("Block num does not fit in i32.");
-                store_block_keys(block_number, block_hash.as_fixed_bytes(), &conn).await;
+                store_block_keys(block_number, block_hash.as_fixed_bytes(), Utc::now(), &conn)
+                    .await;
                 drop(permit);
             });
         }
@@ -287,7 +289,13 @@ pub async fn bulk_download_block_data(
 
                         let block_number =
                             i32::try_from(block_number).expect("Block num does not fit in i32.");
-                        store_block_keys(block_number, block_hash.as_fixed_bytes(), &conn).await;
+                        store_block_keys(
+                            block_number,
+                            block_hash.as_fixed_bytes(),
+                            Utc::now(),
+                            &conn,
+                        )
+                        .await;
                     })
                 })
                 .collect();


### PR DESCRIPTION
Fixes #238 

Also fixes issue where `glados-monitor` was using the time that the content key enters the DB, which could be many seconds after the block hit the chain.

![Screen Shot 2024-03-19 at 4 19 01 PM](https://github.com/ethereum/glados/assets/4079737/f108513d-be8f-4e73-ba0c-4c1be1d078ff)
