### PR TITLE
fix: improves sql efficiency

### DIFF
--- a/entity/src/content.rs
+++ b/entity/src/content.rs
@@ -67,6 +67,7 @@ pub async fn get_or_create<T: OverlayContentKey>(
 ) -> Result<Model> {
     // First try to lookup an existing entry.
     if let Some(content_key_model) = Entity::find()
+        .filter(Column::ProtocolId.eq(SubProtocol::History))
         .filter(Column::ContentKey.eq(content_key.to_bytes()))
         .one(conn)
         .await?

--- a/migration/src/lib.rs
+++ b/migration/src/lib.rs
@@ -10,6 +10,7 @@ mod m20230511_104838_create_execution_metadata;
 mod m20230511_104937_create_key_value;
 mod m20231107_004843_create_audit_stats;
 mod m20240213_190221_add_fourfours_stats;
+mod m20240322_205213_add_content_audit_index;
 
 pub struct Migrator;
 
@@ -17,6 +18,7 @@ pub struct Migrator;
 impl MigratorTrait for Migrator {
     fn migrations() -> Vec<Box<dyn MigrationTrait>> {
         vec![
+            Box::new(m20230508_111707_create_census_tables::Migration),
             Box::new(m20230511_104804_create_node::Migration),
             Box::new(m20230511_104811_create_record::Migration),
             Box::new(m20230511_104814_create_content::Migration),
@@ -24,9 +26,9 @@ impl MigratorTrait for Migrator {
             Box::new(m20230511_104830_create_content_audit::Migration),
             Box::new(m20230511_104838_create_execution_metadata::Migration),
             Box::new(m20230511_104937_create_key_value::Migration),
-            Box::new(m20230508_111707_create_census_tables::Migration),
             Box::new(m20231107_004843_create_audit_stats::Migration),
             Box::new(m20240213_190221_add_fourfours_stats::Migration),
+            Box::new(m20240322_205213_add_content_audit_index::Migration),
         ]
     }
 }

--- a/migration/src/m20240322_205213_add_content_audit_index.rs
+++ b/migration/src/m20240322_205213_add_content_audit_index.rs
@@ -1,0 +1,37 @@
+use sea_orm_migration::prelude::*;
+
+#[derive(DeriveMigrationName)]
+pub struct Migration;
+
+const INDEX_CONTENT_AUDIT_CONTENT_RELATION: &str = "idx_content_audit_content_fk";
+
+#[async_trait::async_trait]
+impl MigrationTrait for Migration {
+    async fn up(&self, manager: &SchemaManager) -> Result<(), DbErr> {
+        manager
+            .create_index(
+                Index::create()
+                    .name(INDEX_CONTENT_AUDIT_CONTENT_RELATION)
+                    .table(ContentAudit::Table)
+                    .col(ContentAudit::ContentKey)
+                    .to_owned(),
+            )
+            .await
+    }
+
+    async fn down(&self, manager: &SchemaManager) -> Result<(), DbErr> {
+        manager
+            .drop_index(
+                Index::drop()
+                    .name(INDEX_CONTENT_AUDIT_CONTENT_RELATION)
+                    .to_owned(),
+            )
+            .await
+    }
+}
+
+#[derive(Iden)]
+enum ContentAudit {
+    Table,
+    ContentKey,
+}


### PR DESCRIPTION
**What was wrong?**

Some of our sql operations are inefficient and are taking seconds to run at scale while redlining cpu/mem on the glados host.

**What was fixed?**

1. `content` table has an index on `(protocol-id, content-key)`, but the `get_or_create` function was only doing a filter on `content-key` so this index wasn't being used and `content` creation was taking a long time. Filtering on `protocol-id` makes both indexes get used.
2. `content_audit` table was missing an index for the foreign key to the `content` table. Joining the `content_audit` table on the `content` table is necessary for the `latest` and `oldest` strategies, and those queries were taking a long time.
3. The `random` selection strategy had two inefficiencies: 1.) we were using `COUNT` to get all of the content IDs so that we could randomly sample from them, this requires scanning the entire table which was taking seconds. Using `MAX` instead makes it instant. 2.) with the IDs for the content in the DB that we wanted to lookup, we were doing a separate sql query for each one. Doing a single sql query to get all (up to 100) keys results in a 10x speed-up. 





