### PR TITLE
fix: use index in content::get

### DIFF
--- a/entity/src/content.rs
+++ b/entity/src/content.rs
@@ -92,6 +92,7 @@ pub async fn get<T: OverlayContentKey>(
     conn: &DatabaseConnection,
 ) -> Result<Option<Model>> {
     Ok(Entity::find()
+        .filter(Column::ProtocolId.eq(SubProtocol::History))
         .filter(Column::ContentKey.eq(content_key.to_bytes()))
         .one(conn)
         .await?)


### PR DESCRIPTION
#246 fixed a problem with `content::get_or_create`. Turns out `content::get` had the same issue, and this fixes it. 