### PR TITLE
feat: use postgres instead of sqlite for tests & ci

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -85,6 +85,9 @@ jobs:
                 name: Install libssl-dev for openssl-sys
                 command: sudo apt install -y libssl-dev clang
             - run:
+                name: Install postgres for testing
+                command: sudo apt install -y postgresql postgresql-client
+            - run:
                 name: Install rustfmt
                 command: rustup component add rustfmt
             - run:
@@ -101,7 +104,7 @@ jobs:
                 command: cargo build --workspace
             - run:
                 name: Test Glados workspace
-                command: cargo test --workspace -- --nocapture
+                command: export POSTGRES_PATH=$(find /usr/lib/postgresql/ -type d -name "bin") && PATH=$PATH:$POSTGRES_PATH cargo test --workspace -- --nocapture
 workflows:
   merge-test:
     jobs:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -104,7 +104,8 @@ jobs:
                 command: cargo build --workspace
             - run:
                 name: Test Glados workspace
-                command: export POSTGRES_PATH=$(find /usr/lib/postgresql/ -type d -name "bin") && PATH=$PATH:$POSTGRES_PATH cargo test --workspace -- --nocapture
+                # Add postgresql bin to the PATH and then run the tests.
+                command: PATH=$PATH:$(find /usr/lib/postgresql/ -type d -name "bin") cargo test --workspace -- --nocapture
 workflows:
   merge-test:
     jobs:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1588,6 +1588,7 @@ dependencies = [
  "ethportal-api",
  "lazy_static",
  "migration",
+ "pgtemp",
  "primitive-types 0.10.1",
  "rand",
  "rstest 0.16.0",
@@ -2018,18 +2019,6 @@ checksum = "46303f565772937ffe1d394a4fac6f411c6013172fadde9dcdb1e147a086940e"
 dependencies = [
  "crc32fast",
  "miniz_oxide",
-]
-
-[[package]]
-name = "flume"
-version = "0.10.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1657b4441c3403d9f7b3409e47575237dac27b1b5726df654a6ecbf92f0f7577"
-dependencies = [
- "futures-core",
- "futures-sink",
- "pin-project",
- "spin 0.9.8",
 ]
 
 [[package]]
@@ -3179,17 +3168,6 @@ dependencies = [
  "bitflags 2.4.2",
  "libc",
  "redox_syscall 0.4.1",
-]
-
-[[package]]
-name = "libsqlite3-sys"
-version = "0.24.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "898745e570c7d0453cc1fbc4a701eb6c662ed54e8fec8b7d14be137ebeeb9d14"
-dependencies = [
- "cc",
- "pkg-config",
- "vcpkg",
 ]
 
 [[package]]
@@ -5191,9 +5169,6 @@ name = "spin"
 version = "0.9.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
-dependencies = [
- "lock_api",
-]
 
 [[package]]
 name = "spki"
@@ -5245,10 +5220,8 @@ dependencies = [
  "dotenvy",
  "either",
  "event-listener 2.5.3",
- "flume",
  "futures-channel",
  "futures-core",
- "futures-executor",
  "futures-intrusive",
  "futures-util",
  "hashlink",
@@ -5258,7 +5231,6 @@ dependencies = [
  "indexmap 1.9.3",
  "itoa",
  "libc",
- "libsqlite3-sys",
  "log",
  "md-5",
  "memchr",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2277,6 +2277,7 @@ dependencies = [
  "ethportal-api",
  "glados-core",
  "migration",
+ "pgtemp",
  "rand",
  "sea-orm",
  "serde_json",
@@ -3699,6 +3700,18 @@ dependencies = [
  "memchr",
  "thiserror",
  "ucd-trie",
+]
+
+[[package]]
+name = "pgtemp"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11fbb73566e38f90abdd281c5e6c0b99152a0c41d409fb35c985ffe02a3f39bc"
+dependencies = [
+ "libc",
+ "tempfile",
+ "tokio",
+ "url",
 ]
 
 [[package]]

--- a/README.md
+++ b/README.md
@@ -20,15 +20,15 @@ The project is split up into a few different crates.
 - [`tokio`](https://tokio.rs/) - Async runtime.
 - [`tracing`](https://docs.rs/tracing/latest/tracing/) - Structured logging
 
-For our database, we use SQLite for local development and Postgres for production.
+For our database, we use Postgres in both development and production.
 
 ### Architecture
 
 The rough shape of Glados is as follows:
 
-The `glados-monitor` crate implements a long running process which continually follows the tip of the chain, and computes the ContentID/ContentKey values for new content as new blocks are added to the canonical chain.  These values are inserted into a relational database (SQLite for local dev, Postgres for production).
+The `glados-monitor` crate implements a long running process which continually follows the tip of the chain, and computes the ContentID/ContentKey values for new content as new blocks are added to the canonical chain.  These values are inserted into a relational database.
 
-A second long running process (that has not yet been written) then queries the database for content that it will then "audit" to determine whether the content can be successfully retrieved from the network.  The audit process will use the Portal Network JSON-RPC api to query the portal network for the given content and then record in the database whether the content could be successfully retrieved.  The database is structured such that a piece of content can be audited many times, giving a historical view over the lifetime of the content showing times when it was or was not available.
+The `glados-audit` process then queries the database for content that it will then "audit" to determine whether the content can be successfully retrieved from the network.  The audit process will use the Portal Network JSON-RPC api to query the portal network for the given content and then record in the database whether the content could be successfully retrieved.  The database is structured such that a piece of content can be audited many times, giving a historical view over the lifetime of the content showing times when it was or was not available.
 
 The `glados-web` crate implements a web application to display information from the database about the audits.  The goal is to have a dashboard that provides a single high level overview of the network health, as well as the ability to drill down into specific pieces of content to see the individual audit history.
 
@@ -43,10 +43,11 @@ See the [DOCKER_GUIDE.md](/DOCKER_GUIDE.md)
 
 ### Basics
 
-When using SQLite you can use an ephemeral in-memory database or one persisted to disk.  This value is referred to as the `DATABASE_URL`
+Glados needs a postgres database to use. To run a postgres instance locally using docker:
 
-- in memory: `sqlite::memory:`
-- persistent: `sqlite:////absolute/path/to/db.sqlite`
+`docker run --name postgres -e POSTGRES_DB=glados POSTGRES_PASSWORD=password -d -p 5432:5432 postgres`
+
+This postgres instance can be accessed via `postgres://postgres:password@localhost:5432/glados`. This value will be referred to as the `DATABASE_URL`.
 
 In most cases, you will want to set the environment variable `RUST_LOG` to enable some level of `debug` level logs.  `RUST_LOG=glados_monitor=debug` is a good way to only enable the debug logs for a specific crate/namespace.
 
@@ -61,7 +62,7 @@ $ cargo run -p glados-monitor -- --database-url <DATABASE_URL> follow-head --pro
 ```
 For example, if an Ethereum execution client is running on localhost port 8545:
 ```
-$ cargo run -p glados-monitor -- --database-url sqlite::memory: follow-head --provider-url http://127.0.0.1:8545
+$ cargo run -p glados-monitor -- --database-url  follow-head --provider-url http://127.0.0.1:8545
 ```
 #### Importing the pre-merge accumulators
 
@@ -76,7 +77,7 @@ $ cargo run -p glados-monitor -- --database-url <DATABASE_URL> import-pre-merge-
 ### Running `glados-web`
 
 
-The CLI needs a DATABASE_URL to know what relational database to connect to, as well as the IPC_PATH which is an absolute path to an IPC socket for a portal client exposing the portal network JSON-RPC api.
+The CLI needs a DATABASE_URL to know what relational database to connect to.
 
 > This has only been tested using the `trin` portal network client.
 

--- a/entity/Cargo.lock
+++ b/entity/Cargo.lock
@@ -610,17 +610,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc7fcc620a3bff7cdd7a365be3376c97191aeaccc2a603e600951e452615bf89"
 
 [[package]]
-name = "libsqlite3-sys"
-version = "0.24.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "898745e570c7d0453cc1fbc4a701eb6c662ed54e8fec8b7d14be137ebeeb9d14"
-dependencies = [
- "cc",
- "pkg-config",
- "vcpkg",
-]
-
-[[package]]
 name = "link-cplusplus"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1155,63 +1144,6 @@ checksum = "9249290c05928352f71c077cc44a464d880c63f26f7534728cca008e135c0428"
 dependencies = [
  "sqlx-core",
  "sqlx-macros",
-]
-
-[[package]]
-name = "sqlx-core"
-version = "0.6.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dcbc16ddba161afc99e14d1713a453747a2b07fc097d2009f4c300ec99286105"
-dependencies = [
- "ahash",
- "atoi",
- "base64",
- "bitflags",
- "byteorder",
- "bytes",
- "chrono",
- "crc",
- "crossbeam-queue",
- "dirs",
- "dotenvy",
- "either",
- "event-listener",
- "flume",
- "futures-channel",
- "futures-core",
- "futures-executor",
- "futures-intrusive",
- "futures-util",
- "hashlink",
- "hex",
- "hkdf",
- "hmac",
- "indexmap",
- "itoa",
- "libc",
- "libsqlite3-sys",
- "log",
- "md-5",
- "memchr",
- "num-bigint",
- "once_cell",
- "paste",
- "percent-encoding",
- "rand",
- "rust_decimal",
- "serde",
- "serde_json",
- "sha1",
- "sha2",
- "smallvec",
- "sqlformat",
- "sqlx-rt",
- "stringprep",
- "thiserror",
- "time",
- "url",
- "uuid",
- "whoami",
 ]
 
 [[package]]

--- a/entity/Cargo.toml
+++ b/entity/Cargo.toml
@@ -18,7 +18,8 @@ ethportal-api = { git = "https://github.com/ethereum/trin" }
 discv5 = "0.4.1"
 lazy_static = "1.4.0"
 migration = { path = "../migration" }
-sea-orm = { version = "0.11.3", features = ["sqlx-postgres", "sqlx-sqlite", "macros", "runtime-tokio-native-tls"] }
+pgtemp = "0.2.1"
+sea-orm = { version = "0.11.3", features = ["sqlx-postgres", "macros", "runtime-tokio-native-tls"] }
 sea-query = "0.28.4"
 tokio = { version = "1.21.2", features = ["macros"] }
 env_logger = "0.10.0"

--- a/glados-audit/Cargo.toml
+++ b/glados-audit/Cargo.toml
@@ -14,6 +14,7 @@ chrono = "0.4.23"
 clap = { version = "4.0.24", features = ["derive"] }
 entity = { path = "../entity" }
 env_logger = "0.9.3"
+pgtemp = "0.2.1"
 enr = "0.10.0"
 ethereum-types = "0.14.0"
 web3 = "0.18.0"

--- a/glados-audit/src/cli.rs
+++ b/glados-audit/src/cli.rs
@@ -1,13 +1,12 @@
 use clap::{ArgAction, Parser, Subcommand, ValueEnum};
 use entity::content_audit::SelectionStrategy;
 
-const DEFAULT_DB_URL: &str = "sqlite::memory:";
 const DEFAULT_STATS_PERIOD: &str = "300";
 
 #[derive(Parser, Debug, Eq, PartialEq)]
 #[command(author, version, about, long_about = None)]
 pub struct Args {
-    #[arg(short, long, default_value = DEFAULT_DB_URL)]
+    #[arg(short, long)]
     pub database_url: String,
     #[arg(
         short,
@@ -75,7 +74,7 @@ pub enum Command {
 impl Default for Args {
     fn default() -> Self {
         Self {
-            database_url: DEFAULT_DB_URL.to_string(),
+            database_url: "".to_string(),
             provider_url: "".to_string(),
             concurrency: 4,
             latest_strategy_weight: 1,
@@ -95,13 +94,21 @@ impl Default for Args {
 mod test {
     use super::*;
 
+    const DATABASE_URL: &str = "postgres://localhost:5432";
+
     /// Tests that the defaults are correct when the minimum required flags are passed.
     #[test]
     fn test_minimum_args() {
         const PORTAL_CLIENT_STRING: &str = "ipc:////path/to/ipc";
-        let result = Args::parse_from(["test", "--portal-client", PORTAL_CLIENT_STRING]);
+        let result = Args::parse_from([
+            "test",
+            "--portal-client",
+            PORTAL_CLIENT_STRING,
+            "--database-url",
+            DATABASE_URL,
+        ]);
         let expected = Args {
-            database_url: DEFAULT_DB_URL.to_string(),
+            database_url: DATABASE_URL.to_string(),
             portal_client: vec![PORTAL_CLIENT_STRING.to_owned()],
             ..Default::default()
         };
@@ -116,9 +123,11 @@ mod test {
             "3",
             "--portal-client",
             PORTAL_CLIENT_STRING,
+            "--database-url",
+            DATABASE_URL,
         ]);
         let expected = Args {
-            database_url: DEFAULT_DB_URL.to_string(),
+            database_url: DATABASE_URL.to_string(),
             concurrency: 3,
             strategy: None,
             portal_client: vec![PORTAL_CLIENT_STRING.to_owned()],
@@ -137,9 +146,11 @@ mod test {
             "latest",
             "--portal-client",
             PORTAL_CLIENT_STRING,
+            "--database-url",
+            DATABASE_URL,
         ]);
         let expected = Args {
-            database_url: DEFAULT_DB_URL.to_string(),
+            database_url: DATABASE_URL.to_string(),
             concurrency: 4,
             strategy: Some(vec![SelectionStrategy::Latest]),
             portal_client: vec![PORTAL_CLIENT_STRING.to_owned()],
@@ -163,9 +174,11 @@ mod test {
             "latest",
             "--strategy",
             "random", // Duplicate is permitted
+            "--database-url",
+            DATABASE_URL,
         ]);
         let expected = Args {
-            database_url: DEFAULT_DB_URL.to_string(),
+            database_url: DATABASE_URL.to_string(),
             concurrency: 4,
             strategy: Some(vec![
                 SelectionStrategy::Random,
@@ -189,8 +202,11 @@ mod test {
             PROVIDER_URL,
             "--portal-client",
             PORTAL_CLIENT_STRING,
+            "--database-url",
+            DATABASE_URL,
         ]);
         let expected = Args {
+            database_url: DATABASE_URL.to_string(),
             provider_url: PROVIDER_URL.to_string(),
             portal_client: vec![PORTAL_CLIENT_STRING.to_owned()],
             ..Default::default()

--- a/glados-audit/src/selection.rs
+++ b/glados-audit/src/selection.rs
@@ -389,7 +389,7 @@ mod tests {
 
     use pgtemp::PgTempDB;
 
-    /// Creates a new in-memory SQLite database for a unit test.
+    /// Creates a temporary Postgres database that will be deleted once the PgTempDB goes out of scope.
     #[allow(dead_code)]
     async fn setup_database() -> Result<(DbConn, PgTempDB), DbErr> {
         let pgtemp = PgTempDB::async_new().await;
@@ -496,7 +496,7 @@ mod tests {
     #[tokio::test]
     async fn test_latest_strategy() {
         // Orchestration
-        let (conn, _) = get_populated_test_audit_db().await.unwrap();
+        let (conn, _db) = get_populated_test_audit_db().await.unwrap();
         const CHANNEL_SIZE: usize = 20;
         let (tx, mut rx) = channel::<AuditTask>(CHANNEL_SIZE);
         // Start strategy
@@ -535,7 +535,7 @@ mod tests {
     #[tokio::test]
     async fn test_select_oldest_unaudited_strategy() {
         // Orchestration
-        let (conn, _) = get_populated_test_audit_db().await.unwrap();
+        let (conn, _db) = get_populated_test_audit_db().await.unwrap();
         const CHANNEL_SIZE: usize = 10;
         let (tx, mut rx) = channel::<AuditTask>(CHANNEL_SIZE);
         // Start strategy
@@ -570,7 +570,7 @@ mod tests {
     #[tokio::test]
     async fn test_random_strategy() {
         // Orchestration
-        let (conn, _) = get_populated_test_audit_db().await.unwrap();
+        let (conn, _db) = get_populated_test_audit_db().await.unwrap();
         const CHANNEL_SIZE: usize = 10;
         let (tx, mut rx) = channel::<AuditTask>(CHANNEL_SIZE);
         // Start strategy

--- a/glados-cartographer/src/cli.rs
+++ b/glados-cartographer/src/cli.rs
@@ -2,8 +2,6 @@ use clap::{Parser, ValueEnum};
 use std::path::PathBuf;
 use url::Url;
 
-const DEFAULT_DB_URL: &str = "sqlite::memory:";
-
 // 15 minutes
 const DEFAULT_CENSUS_INTERVAL: &str = "900";
 
@@ -13,7 +11,7 @@ const DEFAULT_CONCURRENCY: &str = "4";
 #[derive(Clone, Debug, Eq, Parser, PartialEq)]
 #[command(author, version, about, long_about = None)]
 pub struct Args {
-    #[arg(short, long, default_value = DEFAULT_DB_URL)]
+    #[arg(short, long)]
     pub database_url: String,
     #[arg(short = 'p', long, requires = "transport")]
     pub ipc_path: Option<PathBuf>,

--- a/glados-monitor/src/cli.rs
+++ b/glados-monitor/src/cli.rs
@@ -6,7 +6,7 @@ use clap::{Parser, Subcommand};
 #[command(author, version, about, long_about = None)]
 pub struct Cli {
     // Connection to a database where content keys will be injected
-    #[arg(short, long, default_value = "sqlite::memory:")]
+    #[arg(short, long)]
     pub database_url: String,
 
     #[arg(short, long, default_value = "false")]

--- a/glados-monitor/src/main.rs
+++ b/glados-monitor/src/main.rs
@@ -38,7 +38,7 @@ async fn main() -> Result<()> {
         "database connection established"
     );
 
-    if cli.migrate || cli.database_url == "sqlite::memory:" {
+    if cli.migrate {
         info!("running database migrations");
         Migrator::up(&conn, None)
             .await

--- a/glados-web/src/cli.rs
+++ b/glados-web/src/cli.rs
@@ -3,6 +3,6 @@ use clap::Parser;
 #[derive(Parser, Debug)]
 #[command(author, version, about, long_about = None)]
 pub struct Args {
-    #[arg(short, long, default_value = "sqlite::memory:")]
+    #[arg(short, long)]
     pub database_url: String,
 }

--- a/migration/Cargo.toml
+++ b/migration/Cargo.toml
@@ -21,5 +21,4 @@ features = [
   # e.g.
   "runtime-tokio-native-tls",  # `ASYNC_RUNTIME` feature
   "sqlx-postgres",         # `DATABASE_DRIVER` feature
-  "sqlx-sqlite"
 ]

--- a/migration/README.md
+++ b/migration/README.md
@@ -5,21 +5,21 @@ Install
 ```command
 cargo install sea-orm-cli
 ```
-Create (if none already created) a new blank database file:
-```command
-touch /path/to/my-database.sqlite
+Create (if none already created) a new blank postgres instance:
+`docker run --name postgres -e POSTGRES_DB=glados POSTGRES_PASSWORD=password -d -p 5432:5432 postgres`
+`export DATABASE_URL=postgres://postgres:password@localhost:5432/glados`
 ```
 Generate all entities. Commands are made from the project root directory.
 ```command
-DATABASE_URL=sqlite:////path/to/my-database.sqlite sea-orm-cli generate entity -o entity/src
+sea-orm-cli generate entity -o entity/src
 ```
 Generate entity only for `MyNewTable` as defined in a migration (`./migration/src/*.rs`) file:
 ```command
-DATABASE_URL=sqlite:////path/to/my-database.sqlite sea-orm-cli generate entity -o entity/src -t my_new_table
+sea-orm-cli generate entity -o entity/src -t my_new_table
 ```
 Make the tables/changes in the new database:
 ```command
-DATABASE_URL=sqlite:////path/to/my-database.sqlite sea-orm-cli migrate up
+sea-orm-cli migrate up
 ```
 ## Running Migrator CLI
 

--- a/migration/src/lib.rs
+++ b/migration/src/lib.rs
@@ -18,7 +18,6 @@ pub struct Migrator;
 impl MigratorTrait for Migrator {
     fn migrations() -> Vec<Box<dyn MigrationTrait>> {
         vec![
-            Box::new(m20230508_111707_create_census_tables::Migration),
             Box::new(m20230511_104804_create_node::Migration),
             Box::new(m20230511_104811_create_record::Migration),
             Box::new(m20230511_104814_create_content::Migration),
@@ -26,6 +25,7 @@ impl MigratorTrait for Migrator {
             Box::new(m20230511_104830_create_content_audit::Migration),
             Box::new(m20230511_104838_create_execution_metadata::Migration),
             Box::new(m20230511_104937_create_key_value::Migration),
+            Box::new(m20230508_111707_create_census_tables::Migration),
             Box::new(m20231107_004843_create_audit_stats::Migration),
             Box::new(m20240213_190221_add_fourfours_stats::Migration),
             Box::new(m20240322_205213_add_content_audit_index::Migration),


### PR DESCRIPTION
**What's the problem?**

Our production deployments run on postgres, but all our tests run on sqlite. These two are different enough to make our tests (and thus CI results) not necessarily reflective of the behavior of our production deployment. 

**What's the solution?**

Using the `pgtemp` crate to create a postgres instance for unit tests to use. It uses a local installation of postgres instead of installing docker and then downloading postgres, which would make CI take much longer. 

This PR also removes all mentions of sqlite from the repo, and adds instructions for quickly spinning up a local postgres instance via docker.