### PR TITLE
Disable poke for fluffy glados client

### DIFF
--- a/docker-compose-clients.yml
+++ b/docker-compose-clients.yml
@@ -7,4 +7,4 @@ services:
 
   fluffy:
     image: statusim/nimbus-fluffy:amd64-master-latest
-    command: "--rpc --rpc-address=0.0.0.0 --storage-capacity=0"
+    command: "--rpc --rpc-address=0.0.0.0 --storage-capacity=0 --disable-poke"


### PR DESCRIPTION
Fluffy also has this cli option but it never got added here in the docker images.