### PR TITLE
Add data coverage chart

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,4 +85,13 @@ The CLI needs a DATABASE_URL to know what relational database to connect to.
 $ cargo run -p glados-web -- --database-url DATABASE_URL
 ```
 
+This must be run from the project root, or static assets will fail to load, with 404 errors.
+
+### Running a census with `glados-cartographer`
+
+First, launch a portal client, like trin, with an HTTP endpoint. Assuming you already launched postgres using Docker, the cartographer command would look like:
+```sh
+cargo run -p glados-cartographer -- --database-url postgres://postgres:password@localhost:5432/glados --transport http --http-url http://localhost:8545 --concurrency 10
+```
+
 You should then be able to view the web application at `http://127.0.0.1:3001/` in your browser.

--- a/glados-web/src/lib.rs
+++ b/glados-web/src/lib.rs
@@ -2,7 +2,7 @@ use std::sync::Arc;
 use std::{net::SocketAddr, path::Path};
 
 use anyhow::{bail, Result};
-use axum::http::StatusCode;
+use axum::http::{StatusCode, Uri};
 use axum::{
     extract::Extension,
     routing::{get, get_service},
@@ -113,7 +113,7 @@ pub async fn run_glados_web(config: Arc<State>) -> Result<()> {
 }
 
 /// Global routing error handler to prevent panics.
-async fn handler_404() -> StatusCode {
-    tracing::error!("404: Non-existent page visited");
+async fn handler_404(uri: Uri) -> StatusCode {
+    tracing::error!("404: Nothing to serve for '{uri}'");
     StatusCode::NOT_FOUND
 }

--- a/glados-web/src/routes.rs
+++ b/glados-web/src/routes.rs
@@ -29,8 +29,7 @@ use std::collections::{HashMap, HashSet};
 use std::fmt::Formatter;
 use std::sync::Arc;
 use std::{fmt::Display, io};
-use tracing::error;
-use tracing::info;
+use tracing::{error, info, warn};
 
 use crate::templates::{
     AuditDashboardTemplate, AuditTableTemplate, CensusExplorerTemplate, ContentAuditDetailTemplate,
@@ -208,7 +207,7 @@ async fn get_max_census_id(state: &Arc<State>) -> Option<MaxCensusId> {
     {
         Ok(val) => val,
         Err(err) => {
-            error!("{err}");
+            warn!("Census data unavailable: {err}");
             None
         }
     }

--- a/glados-web/src/routes.rs
+++ b/glados-web/src/routes.rs
@@ -74,6 +74,10 @@ pub struct RadiusChartData {
 #[derive(Serialize, Debug)]
 pub struct CalculatedRadiusChartData {
     pub data_radius: f64,
+    /// Top byte of the advertised radius
+    pub radius_top: u8,
+    /// Percentage coverage, not including the top byte
+    pub radius_lower_fraction: f64,
     pub node_id: u64,
     pub node_id_string: String,
     pub raw_enr: String,
@@ -157,13 +161,12 @@ async fn generate_radius_graph_data(state: &Arc<State>) -> Vec<CalculatedRadiusC
 
     let mut radius_percentages: Vec<CalculatedRadiusChartData> = vec![];
     for i in radius_chart_data {
-        let radius_high_bytes: [u8; 4] = [
+        let radius_fraction = xor_distance_to_fraction([
             i.data_radius[0],
             i.data_radius[1],
             i.data_radius[2],
             i.data_radius[3],
-        ];
-        let radius_int = u32::from_be_bytes(radius_high_bytes);
+        ]);
         let node_id_high_bytes: [u8; 8] = [
             i.node_id[0],
             i.node_id[1],
@@ -175,17 +178,25 @@ async fn generate_radius_graph_data(state: &Arc<State>) -> Vec<CalculatedRadiusC
             i.node_id[7],
         ];
 
-        let percentage = (radius_int as f64 / u32::MAX as f64) * 100.0;
-        let formatted_percentage = format!("{:.2}", percentage);
+        let formatted_percentage = format!("{:.2}", radius_fraction * 100.0);
 
         let mut node_id_bytes: [u8; 32] = [0; 32];
         if i.node_id.len() == 32 {
             node_id_bytes.copy_from_slice(&i.node_id);
         }
 
+        let radius_lower_fraction = xor_distance_to_fraction([
+            i.data_radius[1],
+            i.data_radius[2],
+            i.data_radius[3],
+            i.data_radius[4],
+        ]);
+
         let node_id_string = hex_encode(node_id_bytes);
         radius_percentages.push(CalculatedRadiusChartData {
             data_radius: formatted_percentage.parse().unwrap(),
+            radius_top: i.data_radius[0],
+            radius_lower_fraction,
             node_id: u64::from_be_bytes(node_id_high_bytes),
             node_id_string,
             raw_enr: i.raw,
@@ -193,6 +204,11 @@ async fn generate_radius_graph_data(state: &Arc<State>) -> Vec<CalculatedRadiusC
     }
 
     radius_percentages
+}
+
+fn xor_distance_to_fraction(radius_high_bytes: [u8; 4]) -> f64 {
+    let radius_int = u32::from_be_bytes(radius_high_bytes);
+    radius_int as f64 / u32::MAX as f64
 }
 
 async fn get_max_census_id(state: &Arc<State>) -> Option<MaxCensusId> {

--- a/glados-web/templates/index.html
+++ b/glados-web/templates/index.html
@@ -79,13 +79,24 @@
                 </div>
             </div>
         </div>
+        <div class="col-lg-13 col-md-18 col-sm-18 margin-bottom">
+            <div class="card pie-box h-100">
+                <div class="card-body">
+                    <div class="table-responsive">
+                        <div id="census-stacked"></div>
+                    </div>
+                </div>
+            </div>
+        </div>
     </div>
 
 </div>
 <script>
-    pie_chart_count({{ client_diversity_data| json | safe }})
-    radius_node_id_scatter_chart({{ average_radius_chart| json | safe }})
-    statsHistoryChart()
+    pie_chart_count({{ client_diversity_data| json | safe }});
+    const census_data = {{ average_radius_chart| json | safe }};
+    radius_node_id_scatter_chart(census_data);
+    radius_stacked_chart(census_data);
+    statsHistoryChart();
 
 </script>
 


### PR DESCRIPTION
Fix #261 

Adds a chart to the home page, showing how much coverage there is in the best case.

Here's an example from a real census run on my machine a few days ago:
![image](https://github.com/ethereum/glados/assets/205327/5dab14fb-9a96-4651-887f-2f3c9f67afc4)

The basic approach is to split the keyspace into 256 1-byte buckets. Then show how many nodes fully cover that keyspace, and how much partial coverage there is of those buckets.

This mostly reuses the existing data from the node radius chart, plus a bit more precision in the radius calculation sent by the server.

Also, I added a tooltip to help you see which bucket is showing which data, and the precise value of coverage. I am a little unsatisfied with the method of identifying the bucket prefix (back-calculating from the x-value), but I couldn't find a better solution after digging a bit. I'm open to suggestions.

Note: there are a few little fix-up commits working on the logs and readme. It may be easier to review by commit.

TODO:
- [x] remove TODO comments, they should be fully captured in #267 now
- [ ] squash comment removal and tooltip into the "add chart" commit