### PR TITLE
feat: highlight 4444s stats

### DIFF
--- a/glados-web/assets/js/stats_history.js
+++ b/glados-web/assets/js/stats_history.js
@@ -100,7 +100,7 @@ function createMultiLineChart(height, width, dataSets) {
     }
 
     // Select all '.legend' group elements and click on all but the first three
-    let selectedIndexes = [1, 4]
+    let selectedIndexes = [3]
     svg.selectAll(".legend")
         .each(function (d, i) {
             if (!selectedIndexes.includes(i)) {

--- a/glados-web/templates/index.html
+++ b/glados-web/templates/index.html
@@ -17,7 +17,7 @@
         <div class="col-lg-9 col-md-6 col-sm-12 margin-bottom">
             <div class="card pie-box h-100">
                 <div class="card-body">
-                    <h2>Audit stats</h2>
+                    <h2>4444s stats</h2>
                     <div class="table-responsive">
                         <table class="table">
                             <thead>


### PR DESCRIPTION
a previous PR accidentally made 4444s stats no longer the default chart graphed, this PR:

- fixes that
- makes the stats table on the main glados page show 4444s stats because that's what we're focused on getting to 100%