### PR TITLE
fix: show shisui color and client name

### DIFF
--- a/glados-web/assets/js/radiusdensity.js
+++ b/glados-web/assets/js/radiusdensity.js
@@ -234,6 +234,7 @@ function radius_node_id_scatter_chart(data) {
             let blue = '#3498DB'
             let purple = '#9B59B6'
             let orange = '#E67E22'
+            let red = '#DA251D'
             let grey = '#808080'
             const clientString = getClientStringFromDecodedEnr(d.raw_enr);
                 if (clientString[0] === "f") {
@@ -242,6 +243,8 @@ function radius_node_id_scatter_chart(data) {
                     return purple; 
                 } else if (clientString[0] === "u") {
                     return orange; 
+                } else if (clientString[0] === "s") {
+                  return red; 
                 } else {
                     return grey; 
                 }

--- a/glados-web/assets/js/trace/enr.js
+++ b/glados-web/assets/js/trace/enr.js
@@ -113,6 +113,9 @@
                                     // ASCII 'f'
                                     case 0x66:
                                         return 'fluffy';
+                                        // ASCII 's'
+                                    case 0x73:
+                                        return 'shisui';
                                     default:
                                         return undefined;
                                 }


### PR DESCRIPTION
1. census scatterplot show the right color
<img width="576" alt="image" src="https://github.com/ethereum/glados/assets/21964308/e5f57b60-67c7-4516-98b5-00d222344c7a">

2. show client name in audit detail page
<img width="578" alt="image" src="https://github.com/ethereum/glados/assets/21964308/e85910e3-815d-4b17-b5cf-e6835d6aabc4">
