### PR TITLE
feat: angelfood docker compose file

### DIFF
--- a/docker-compose-angelfood.yml
+++ b/docker-compose-angelfood.yml
@@ -1,0 +1,83 @@
+version: '3'
+services:
+
+  glados_postgres:
+    image: postgres:latest
+    environment:
+      POSTGRES_USER: postgres
+      POSTGRES_PASSWORD: ${GLADOS_POSTGRES_PASSWORD?Glados Postgres Password Required}
+      POSTGRES_DB: glados
+    volumes:
+      - ${GLADOS_POSTGRES_DATA_DIR?Glados Postgres Data Directory Required}:/var/lib/postgresql/data
+    ports:
+      - "5432:5432"
+    networks:
+      - glados-net
+    restart: always
+
+  portal_client:
+    extends:
+      file: docker-compose-clients.yml
+      service: ${GLADOS_PORTAL_CLIENT?Glados portal client required}
+    hostname: portal-client
+    network_mode: "host"
+    restart: always
+
+  glados_audit:
+    command: "--database-url postgres://postgres:${GLADOS_POSTGRES_PASSWORD}@glados_postgres:5432/glados --portal-client http://host.docker.internal:8545 --concurrency 8 --history=false --state --provider-url ${GLADOS_PROVIDER_URL?Provider URL required}"
+    image: portalnetwork/glados-audit:latest
+    environment:
+      RUST_LOG: warn,glados_audit=info
+    depends_on:
+      - glados_postgres
+      - portal_client
+    networks:
+      - glados-net
+    extra_hosts:
+      - "host.docker.internal:host-gateway"
+    restart: always
+
+  glados_monitor:
+    command: "--database-url postgres://postgres:${GLADOS_POSTGRES_PASSWORD}@glados_postgres:5432/glados populate-state-roots-range --start-block-number 0 --end-block-number 11 --provider-url ${GLADOS_PROVIDER_URL?Glados monitor provider URL required}"
+    image: portalnetwork/glados-monitor:latest
+    environment:
+      RUST_LOG: warn,glados_monitor=info
+    depends_on:
+      - glados_audit
+      - glados_postgres
+    networks:
+      - glados-net
+    restart: always
+
+  glados_web:
+    command: "--database-url postgres://postgres:${GLADOS_POSTGRES_PASSWORD}@glados_postgres:5432/glados"
+    image: portalnetwork/glados-web:latest
+    environment:
+      RUST_LOG: warn,glados_web=info
+    depends_on:
+      - glados_monitor
+      - glados_postgres
+    ports:
+      - "3001:3001"
+    networks:
+      - glados-net
+    restart: always
+
+  glados_cartographer:
+    command: "--database-url postgres://postgres:${GLADOS_POSTGRES_PASSWORD}@glados_postgres:5432/glados --transport http --http-url http://host.docker.internal:8545 --concurrency 10"
+    image: portalnetwork/glados-cartographer:latest
+    environment:
+      RUST_LOG: warn,glados_cartographer=info
+    depends_on:
+      - glados_web
+      - glados_postgres
+      - portal_client
+    networks:
+      - glados-net
+    extra_hosts:
+      - "host.docker.internal:host-gateway"
+    restart: always
+
+networks:
+  glados-net:
+    driver: bridge

--- a/docker-compose-clients.yml
+++ b/docker-compose-clients.yml
@@ -3,8 +3,7 @@ services:
     image: portalnetwork/trin:latest
     environment:
       RUST_LOG: info
-    command: "--web3-transport http --web3-http-address http://0.0.0.0:8545/ --mb 0 --no-upnp --disable-poke"
-
+    command: "--web3-transport http --web3-http-address http://0.0.0.0:8545/ --mb 0 --no-upnp --disable-poke ${GLADOS_CLIENT_ARGUMENTS:-}"
   fluffy:
     image: statusim/nimbus-fluffy:amd64-master-latest
-    command: "--rpc --rpc-address=0.0.0.0 --storage-capacity=0 --disable-poke"
+    command: "--rpc --rpc-address=0.0.0.0 --storage-capacity=0 --disable-poke ${GLADOS_CLIENT_ARGUMENTS:-}"


### PR DESCRIPTION
We recently set up our first testnet angelfood.

we want to have a glados instance for it using glados.


In the PR I make a new docker compose file configured for running an instance of Glados for out testnet Angelfood. With state audit enabled along with extending our client docker compose file to be able to run other networks

It can be found here https://glados-angelfood.ethdevops.io/audits/