### PR TITLE
refactor: updated glados to use ethportal-api instead of custom json-rpc code

### DIFF
--- a/glados-audit/src/lib.rs
+++ b/glados-audit/src/lib.rs
@@ -348,7 +348,7 @@ async fn perform_single_audit(
 
     debug!(
         content.key = hex_encode(&task.content.content_key),
-        client.url = client.api.client_url.clone(),
+        client.url =? client.api.client,
         "auditing content",
     );
     let (content_response, trace) = if client.supports_trace() {

--- a/glados-audit/src/state.rs
+++ b/glados-audit/src/state.rs
@@ -17,10 +17,7 @@ use ethportal_api::{
     },
     StateContentKey, StateContentValue, StateNetworkApiClient,
 };
-use glados_core::{
-    db::store_content_key,
-    jsonrpc::{PortalApi, PortalClient, Transport},
-};
+use glados_core::{db::store_content_key, jsonrpc::PortalClient};
 use rand::seq::IteratorRandom;
 use sea_orm::DatabaseConnection;
 use tokio::time::sleep;
@@ -257,12 +254,7 @@ pub async fn spawn_state_audit(conn: DatabaseConnection, config: AuditConfig) {
                 }
             };
 
-            let transport = PortalApi::parse_client_url(portal_client.api.client_url.clone())
-                .await
-                .expect("Failed to parse client url.");
-            let client = match transport {
-                Transport::HTTP(http) => http.client,
-            };
+            let client = portal_client.api.client.clone();
 
             let (state_audit_result, content_key) =
                 match random_state_walk(state_root, client).await {

--- a/glados-core/src/jsonrpc.rs
+++ b/glados-core/src/jsonrpc.rs
@@ -1,6 +1,6 @@
 use std::{path::PathBuf, time::Duration};
 
-use anyhow::{anyhow, Ok};
+use alloy_primitives::hex::FromHexError;
 use entity::content;
 use ethportal_api::types::enr::Enr;
 use ethportal_api::types::{
@@ -8,12 +8,14 @@ use ethportal_api::types::{
     history::{ContentInfo as HistoryContentInfo, TraceContentInfo as HistoryTraceContentInfo},
     state::{ContentInfo as StateContentInfo, TraceContentInfo as StateTraceContentInfo},
 };
+use ethportal_api::utils::bytes::ByteUtilsError;
 use ethportal_api::{
-    BeaconNetworkApiClient, ContentValue, Discv5ApiClient, HistoryNetworkApiClient, NodeInfo,
-    RoutingTableInfo, StateNetworkApiClient, Web3ApiClient,
+    BeaconNetworkApiClient, ContentKeyError, ContentValue, Discv5ApiClient,
+    HistoryNetworkApiClient, NodeInfo, RoutingTableInfo, StateNetworkApiClient, Web3ApiClient,
 };
 use jsonrpsee::http_client::{HttpClient, HttpClientBuilder};
 use serde_json::json;
+use thiserror::Error;
 use url::Url;
 
 /// Configuration details for connection to a Portal network node.
@@ -35,12 +37,93 @@ pub struct PortalClient {
     pub enr: Enr,
 }
 
+const CONTENT_NOT_FOUND_ERROR_CODE: i32 = -39001;
+#[derive(Error, Debug)]
+pub enum JsonRpcError {
+    #[error("received formatted response with no error, but contains a None result")]
+    ContainsNone,
+
+    #[error("received empty response (EOF only)")]
+    Empty,
+
+    #[error("HTTP client error: {0}")]
+    HttpClient(String),
+
+    /// Portal network defines "0x" as the response for absent content.
+    #[error("expected special 0x 'content absent' message for content request, received HTTP response with None result")]
+    SpecialMessageExpected,
+
+    /// Portal network defines "0x" as the response for absent content.
+    #[error("received special 0x 'content absent' message for non-content request, expected HTTP response with None result")]
+    SpecialMessageUnexpected,
+
+    #[error("unable to convert `{enr_string}` into ENR due to {error}")]
+    InvalidEnr {
+        error: String, // This source doesn't implement Error
+        enr_string: String,
+    },
+
+    #[error("unable to convert {input} to hash")]
+    InvalidHash { source: FromHexError, input: String },
+
+    #[error("invalid integer conversion")]
+    InvalidIntegerConversion(#[from] std::num::TryFromIntError),
+
+    #[error("unable to convert string `{input}`")]
+    InvalidJson {
+        source: serde_json::Error,
+        input: String,
+    },
+
+    #[error("non-specific I/O error")]
+    IO(#[from] std::io::Error),
+
+    #[error("received malformed response: {0}")]
+    Malformed(serde_json::Error),
+
+    #[error("malformed portal client URL")]
+    ClientURL { url: String },
+
+    #[error("unable to use byte utils {0}")]
+    ByteUtils(#[from] ByteUtilsError),
+
+    #[error("unable to serialize/deserialize")]
+    Serialization(#[from] serde_json::Error),
+
+    #[error("could not open file {path:?}")]
+    OpenFileFailed {
+        source: std::io::Error,
+        path: PathBuf,
+    },
+
+    #[error("Couldn't convert bytes to ContentKey")]
+    ContentKeyError(#[from] ContentKeyError),
+
+    #[error("Query completed without finding content")]
+    ContentNotFound { trace: Option<String> },
+}
+
+impl From<jsonrpsee::core::error::Error> for JsonRpcError {
+    fn from(e: jsonrpsee::core::error::Error) -> Self {
+        if let jsonrpsee::core::error::Error::Call(ref error) = e {
+            if error.code() == CONTENT_NOT_FOUND_ERROR_CODE {
+                return JsonRpcError::ContentNotFound {
+                    trace: error.data().map(|data| data.to_string()),
+                };
+            }
+        }
+
+        // Fallback to the generic HttpClient error variant if no match
+        JsonRpcError::HttpClient(e.to_string())
+    }
+}
+
 pub struct Content {
     pub raw: Vec<u8>,
 }
 
 impl PortalClient {
-    pub async fn from(portal_client_url: String) -> Result<Self, anyhow::Error> {
+    pub async fn from(portal_client_url: String) -> Result<Self, JsonRpcError> {
         let api = PortalApi::new(portal_client_url).await?;
 
         let client_info = api.get_client_version().await?;
@@ -60,35 +143,35 @@ impl PortalClient {
 }
 
 impl PortalApi {
-    pub async fn new(client_url: String) -> Result<Self, anyhow::Error> {
+    pub async fn new(client_url: String) -> Result<Self, JsonRpcError> {
         let http_prefix = "http://";
         let client = if client_url.strip_prefix(http_prefix).is_some() {
-            Ok(HttpClientBuilder::default()
+            HttpClientBuilder::default()
                 .request_timeout(Duration::from_secs(120))
-                .build(client_url)?)
+                .build(client_url)?
         } else {
             panic!("None supported RPC interface {client_url}, use http.");
         };
 
-        Ok(PortalApi { client: client? })
+        Ok(PortalApi { client })
     }
 
-    pub async fn get_client_version(&self) -> Result<String, anyhow::Error> {
+    pub async fn get_client_version(&self) -> Result<String, JsonRpcError> {
         Ok(Web3ApiClient::client_version(&self.client).await?)
     }
 
-    pub async fn get_node_info(&self) -> Result<NodeInfo, anyhow::Error> {
+    pub async fn get_node_info(&self) -> Result<NodeInfo, JsonRpcError> {
         Ok(Discv5ApiClient::node_info(&self.client).await?)
     }
 
-    pub async fn get_routing_table_info(self) -> Result<RoutingTableInfo, anyhow::Error> {
+    pub async fn get_routing_table_info(self) -> Result<RoutingTableInfo, JsonRpcError> {
         Ok(Discv5ApiClient::routing_table_info(&self.client).await?)
     }
 
     pub async fn get_content(
         self,
         content: &content::Model,
-    ) -> Result<Option<Content>, anyhow::Error> {
+    ) -> Result<Option<Content>, JsonRpcError> {
         match content.protocol_id {
             content::SubProtocol::History => {
                 let result = HistoryNetworkApiClient::recursive_find_content(
@@ -97,7 +180,7 @@ impl PortalApi {
                 )
                 .await?;
                 let HistoryContentInfo::Content { content, .. } = result else {
-                    return Err(anyhow!("No content found History"));
+                    return Err(JsonRpcError::ContentNotFound { trace: None });
                 };
                 Ok(Some(Content {
                     raw: content.encode(),
@@ -110,7 +193,7 @@ impl PortalApi {
                 )
                 .await?;
                 let StateContentInfo::Content { content, .. } = result else {
-                    return Err(anyhow!("No content found State"));
+                    return Err(JsonRpcError::ContentNotFound { trace: None });
                 };
                 Ok(Some(Content {
                     raw: content.encode(),
@@ -123,7 +206,7 @@ impl PortalApi {
                 )
                 .await?;
                 let BeaconContentInfo::Content { content, .. } = result else {
-                    return Err(anyhow!("No content found Beacon"));
+                    return Err(JsonRpcError::ContentNotFound { trace: None });
                 };
                 Ok(Some(Content {
                     raw: content.encode(),
@@ -135,49 +218,70 @@ impl PortalApi {
     pub async fn get_content_with_trace(
         self,
         content: &content::Model,
-    ) -> Result<(Option<Content>, String), anyhow::Error> {
+    ) -> Result<(Option<Content>, String), JsonRpcError> {
         match content.protocol_id {
             content::SubProtocol::History => {
-                let HistoryTraceContentInfo { content, trace, .. } =
-                    HistoryNetworkApiClient::trace_recursive_find_content(
-                        &self.client,
-                        content.content_key.clone().try_into()?,
-                    )
-                    .await?;
-                Ok((
-                    Some(Content {
-                        raw: content.encode(),
-                    }),
-                    json!(trace).to_string(),
-                ))
+                match HistoryNetworkApiClient::trace_recursive_find_content(
+                    &self.client,
+                    content.content_key.clone().try_into()?,
+                )
+                .await
+                {
+                    Ok(HistoryTraceContentInfo { content, trace, .. }) => Ok((
+                        Some(Content {
+                            raw: content.encode(),
+                        }),
+                        json!(trace).to_string(),
+                    )),
+                    Err(err) => match err.into() {
+                        JsonRpcError::ContentNotFound { trace } => {
+                            Ok((None, trace.unwrap_or_default()))
+                        }
+                        err => Err(err),
+                    },
+                }
             }
             content::SubProtocol::State => {
-                let StateTraceContentInfo { content, trace, .. } =
-                    StateNetworkApiClient::trace_recursive_find_content(
-                        &self.client,
-                        content.content_key.clone().try_into()?,
-                    )
-                    .await?;
-                Ok((
-                    Some(Content {
-                        raw: content.encode(),
-                    }),
-                    json!(trace).to_string(),
-                ))
+                match StateNetworkApiClient::trace_recursive_find_content(
+                    &self.client,
+                    content.content_key.clone().try_into()?,
+                )
+                .await
+                {
+                    Ok(StateTraceContentInfo { content, trace, .. }) => Ok((
+                        Some(Content {
+                            raw: content.encode(),
+                        }),
+                        json!(trace).to_string(),
+                    )),
+                    Err(err) => match err.into() {
+                        JsonRpcError::ContentNotFound { trace } => {
+                            Ok((None, trace.unwrap_or_default()))
+                        }
+                        err => Err(err),
+                    },
+                }
             }
             content::SubProtocol::Beacon => {
-                let BeaconTraceContentInfo { content, trace, .. } =
-                    BeaconNetworkApiClient::trace_recursive_find_content(
-                        &self.client,
-                        content.content_key.clone().try_into()?,
-                    )
-                    .await?;
-                Ok((
-                    Some(Content {
-                        raw: content.encode(),
-                    }),
-                    json!(trace).to_string(),
-                ))
+                match BeaconNetworkApiClient::trace_recursive_find_content(
+                    &self.client,
+                    content.content_key.clone().try_into()?,
+                )
+                .await
+                {
+                    Ok(BeaconTraceContentInfo { content, trace, .. }) => Ok((
+                        Some(Content {
+                            raw: content.encode(),
+                        }),
+                        json!(trace).to_string(),
+                    )),
+                    Err(err) => match err.into() {
+                        JsonRpcError::ContentNotFound { trace } => {
+                            Ok((None, trace.unwrap_or_default()))
+                        }
+                        err => Err(err),
+                    },
+                }
             }
         }
     }


### PR DESCRIPTION
<img width="957" alt="image" src="https://github.com/ethereum/glados/assets/31669092/ffb97968-c745-4898-af05-350d2e982735">
<img width="1285" alt="image" src="https://github.com/ethereum/glados/assets/31669092/c7d032c3-a63f-431e-a469-7a533b2fe435">


In glados we were using custom code for interacting with Portal Clients JSON-RPC. To PR updates glados to use our standard JSON-RPC interfaces through our `ethportal-api` crate