### PR TITLE
feat: add query trace node radius interpolation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1787,19 +1787,6 @@ dependencies = [
 [[package]]
 name = "eth_trie"
 version = "0.4.0"
-source = "git+https://github.com/kolbyml/eth-trie.rs.git?rev=11ec003e3276e1413f06328ab746af5d99f112bb#11ec003e3276e1413f06328ab746af5d99f112bb"
-dependencies = [
- "alloy-primitives",
- "alloy-rlp",
- "hashbrown 0.14.5",
- "keccak-hash",
- "log",
- "parking_lot 0.12.2",
-]
-
-[[package]]
-name = "eth_trie"
-version = "0.4.0"
 source = "git+https://github.com/kolbyml/eth-trie.rs.git?rev=7e57d3dfadee126cc9fda2696fb039bf7b6ed688#7e57d3dfadee126cc9fda2696fb039bf7b6ed688"
 dependencies = [
  "alloy-primitives",
@@ -1942,7 +1929,7 @@ dependencies = [
  "clap 4.5.4",
  "const_format",
  "discv5",
- "eth_trie 0.4.0 (git+https://github.com/kolbyml/eth-trie.rs.git?rev=7e57d3dfadee126cc9fda2696fb039bf7b6ed688)",
+ "eth_trie",
  "ethereum_hashing",
  "ethereum_serde_utils",
  "ethereum_ssz",
@@ -2361,7 +2348,7 @@ dependencies = [
  "enr",
  "entity",
  "env_logger 0.9.3",
- "eth_trie 0.4.0 (git+https://github.com/kolbyml/eth-trie.rs.git?rev=11ec003e3276e1413f06328ab746af5d99f112bb)",
+ "eth_trie",
  "ethportal-api",
  "glados-core",
  "migration",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1798,6 +1798,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "eth_trie"
+version = "0.4.0"
+source = "git+https://github.com/kolbyml/eth-trie.rs.git?rev=7e57d3dfadee126cc9fda2696fb039bf7b6ed688#7e57d3dfadee126cc9fda2696fb039bf7b6ed688"
+dependencies = [
+ "alloy-primitives",
+ "alloy-rlp",
+ "hashbrown 0.14.5",
+ "keccak-hash",
+ "log",
+ "parking_lot 0.12.2",
+]
+
+[[package]]
 name = "ethabi"
 version = "16.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1915,15 +1928,9 @@ dependencies = [
 ]
 
 [[package]]
-name = "ethnum"
-version = "1.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b90ca2580b73ab6a1f724b76ca11ab632df820fd6040c336200d2c1df7b3c82c"
-
-[[package]]
 name = "ethportal-api"
 version = "0.2.2"
-source = "git+https://github.com/ethereum/trin#ea91a76e92981f20212e93c121b613881903aca3"
+source = "git+https://github.com/ethereum/trin#63275a292d88e77e4fbe899ef06f94dadfd05350"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -1935,12 +1942,11 @@ dependencies = [
  "clap 4.5.4",
  "const_format",
  "discv5",
- "eth_trie",
+ "eth_trie 0.4.0 (git+https://github.com/kolbyml/eth-trie.rs.git?rev=7e57d3dfadee126cc9fda2696fb039bf7b6ed688)",
  "ethereum_hashing",
  "ethereum_serde_utils",
  "ethereum_ssz",
  "ethereum_ssz_derive",
- "ethnum",
  "hex",
  "jsonrpsee",
  "keccak-hash",
@@ -1956,10 +1962,8 @@ dependencies = [
  "serde",
  "serde-this-or-that",
  "serde_json",
- "serde_yaml",
  "sha2",
  "sha3 0.9.1",
- "snap",
  "ssz_types",
  "superstruct",
  "thiserror",
@@ -2357,7 +2361,7 @@ dependencies = [
  "enr",
  "entity",
  "env_logger 0.9.3",
- "eth_trie",
+ "eth_trie 0.4.0 (git+https://github.com/kolbyml/eth-trie.rs.git?rev=11ec003e3276e1413f06328ab746af5d99f112bb)",
  "ethportal-api",
  "glados-core",
  "migration",
@@ -2445,6 +2449,7 @@ dependencies = [
  "axum",
  "chrono",
  "clap 4.5.4",
+ "enr",
  "entity",
  "env_logger 0.9.3",
  "ethportal-api",
@@ -4967,19 +4972,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "serde_yaml"
-version = "0.9.34+deprecated"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a8b1a1a2ebf674015cc02edccce75287f1a0130d394307b36743c2f5d504b47"
-dependencies = [
- "indexmap 2.2.6",
- "itoa",
- "ryu",
- "serde",
- "unsafe-libyaml",
-]
-
-[[package]]
 name = "sha-1"
 version = "0.9.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5107,12 +5099,6 @@ name = "smallvec"
 version = "1.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3c5e1a9a646d36c3599cd173a41282daf47c44583ad367b8e6837255952e5c67"
-
-[[package]]
-name = "snap"
-version = "1.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b6b67fb9a61334225b5b790716f609cd58395f895b3fe8b328786812a40bc3b"
 
 [[package]]
 name = "socket2"
@@ -5805,7 +5791,7 @@ dependencies = [
 [[package]]
 name = "trin-utils"
 version = "0.1.1-alpha.1"
-source = "git+https://github.com/ethereum/trin#ea91a76e92981f20212e93c121b613881903aca3"
+source = "git+https://github.com/ethereum/trin#63275a292d88e77e4fbe899ef06f94dadfd05350"
 dependencies = [
  "ansi_term",
  "atty",
@@ -5935,12 +5921,6 @@ dependencies = [
  "generic-array",
  "subtle",
 ]
-
-[[package]]
-name = "unsafe-libyaml"
-version = "0.2.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "673aac59facbab8a9007c7f6108d11f63b603f7cabff99fabf650fea5c32b861"
 
 [[package]]
 name = "untrusted"

--- a/glados-audit/Cargo.toml
+++ b/glados-audit/Cargo.toml
@@ -17,7 +17,7 @@ entity = { path = "../entity" }
 env_logger = "0.9.3"
 pgtemp = "0.2.1"
 enr = "0.10.0"
-eth_trie = { git = "https://github.com/kolbyml/eth-trie.rs.git", rev = "11ec003e3276e1413f06328ab746af5d99f112bb" }
+eth_trie = { git = "https://github.com/kolbyml/eth-trie.rs.git", rev = "7e57d3dfadee126cc9fda2696fb039bf7b6ed688" }
 web3 = "0.18.0"
 ethportal-api = { git = "https://github.com/ethereum/trin" }
 glados-core = { path = "../glados-core" }

--- a/glados-web/Cargo.toml
+++ b/glados-web/Cargo.toml
@@ -18,6 +18,7 @@ clap = { version = "4.0.26", features = ["derive"] }
 entity = { path = "../entity" }
 env_logger = "0.9.3"
 ethportal-api = { git = "https://github.com/ethereum/trin" }
+enr = "0.10.0"
 glados-core = { path = "../glados-core" }
 migration = { path = "../migration" }
 itertools = "0.10.5"

--- a/glados-web/assets/css/trace.css
+++ b/glados-web/assets/css/trace.css
@@ -100,6 +100,19 @@
   background: #edc949;
 }
 
+.should-store-legend-dot {
+    background: white;
+    width: 12px;
+    height: 12px;
+    border-radius: 5;
+    border: 3px solid lightgray;
+    -moz-border-radius: 10px;
+    border-radius: 10px;
+    margin-top: 5px;
+    margin-left: 6px;
+    margin-right: 3px;
+}
+
 .previous {
     margin-left: 10px;
 }

--- a/glados-web/assets/js/trace/graph.js
+++ b/glados-web/assets/js/trace/graph.js
@@ -19,7 +19,7 @@ function ForceGraph({
     linkTarget = ({ target }) => target, // given d in links, returns a node identifier string
     linkStroke = "#999", // link stroke color
     linkStrokeOpacity = 0.6, // link stroke opacity
-    linkStrokeWidth = 1.5, // given d in links, returns a stroke width in pixels
+    linkStrokeWidth = 5, // given d in links, returns a stroke width in pixels
     linkStrokeLinecap = "round", // link stroke linecap
     linkStrength,
     colors = d3.schemeTableau10, // an array of color strings, for the node groups

--- a/glados-web/templates/contentaudit_detail.html
+++ b/glados-web/templates/contentaudit_detail.html
@@ -44,6 +44,8 @@
             <text>Content Found</text>
             <div class="legend-dot" id="cancelled"></div>
             <text>Request Cancelled</text>
+            <div class="should-store-legend-dot" id="should-store"></div>
+            <text>Should Store</text>
         </div>
 
     </div>
@@ -57,6 +59,7 @@
                     <th scope="col">Distance from Content</th>
                     <th scope="col">Address</th>
                     <th scope="col">Client</th>
+                    <th scope="col">Should Store</th>
                 </tr>
             </thead>
             <tbody id="enr-table">
@@ -82,6 +85,20 @@
         let graphSvg = createGraph(graphData);
         $('#graph').append(graphSvg);
 
+        // Highlight the nodes for whom the content is within radius.
+        d3.selectAll("g").selectAll("circle")
+            .filter(d => {
+                const node_id = d.id;
+                let metadata = trace.metadata[node_id];
+                if (metadata.radius !== null) {
+                    const distance = BigInt(metadata.distance);
+                    const radius = BigInt(metadata.radius);
+                    return distance < radius;
+                }
+                return false;
+            })
+            .attr("stroke", "lightgray")
+            .attr("stroke-width", 3);
         generateTable(graphData.nodes);
 
         $('#trin-button').on("mouseenter", function () {

--- a/migration/src/lib.rs
+++ b/migration/src/lib.rs
@@ -12,6 +12,7 @@ mod m20231107_004843_create_audit_stats;
 mod m20240213_190221_add_fourfours_stats;
 mod m20240322_205213_add_content_audit_index;
 mod m20240515_064320_state_roots;
+mod m20240720_111606_create_census_index;
 
 pub struct Migrator;
 
@@ -31,6 +32,7 @@ impl MigratorTrait for Migrator {
             Box::new(m20240213_190221_add_fourfours_stats::Migration),
             Box::new(m20240322_205213_add_content_audit_index::Migration),
             Box::new(m20240515_064320_state_roots::Migration),
+            Box::new(m20240720_111606_create_census_index::Migration),
         ]
     }
 }

--- a/migration/src/m20240720_111606_create_census_index.rs
+++ b/migration/src/m20240720_111606_create_census_index.rs
@@ -1,0 +1,39 @@
+use sea_orm_migration::prelude::*;
+
+#[derive(DeriveMigrationName)]
+pub struct Migration;
+
+const INDEX_CENSUS_RECORD_ID_SURVEYED_AT: &str = "idx_census_record_id_surveyed_at";
+
+#[derive(Iden)]
+enum CensusNode {
+    Table,
+    RecordId,
+    SurveyedAt,
+}
+
+#[async_trait::async_trait]
+impl MigrationTrait for Migration {
+    async fn up(&self, manager: &SchemaManager) -> Result<(), DbErr> {
+        manager
+            .create_index(
+                Index::create()
+                    .name(INDEX_CENSUS_RECORD_ID_SURVEYED_AT)
+                    .table(CensusNode::Table)
+                    .col(CensusNode::RecordId)
+                    .col(CensusNode::SurveyedAt)
+                    .to_owned(),
+            )
+            .await
+    }
+
+    async fn down(&self, manager: &SchemaManager) -> Result<(), DbErr> {
+        manager
+            .drop_index(
+                Index::drop()
+                    .name(INDEX_CENSUS_RECORD_ID_SURVEYED_AT)
+                    .to_owned(),
+            )
+            .await
+    }
+}


### PR DESCRIPTION
Implements #161

**What was wrong?**

Query traces don't show any information about whether a given node should have had the data, according to its radius at the time of the trace.

**How was this fixed?**
A lookup is done to find in census data the radius for each node closest to the time at which the trace took place. This information is encoded within the `QueryTrace` object, and then visualized client-side.

![Screenshot 2024-07-11 at 4 01 21 PM](https://github.com/ethereum/glados/assets/4079737/b60eafee-1f32-425e-90c2-9ee828c8fa83)
