### PR TITLE
Switch Cargo.toml in packages to use workspace dependencies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2347,7 +2347,7 @@ dependencies = [
  "clap 4.5.4",
  "enr",
  "entity",
- "env_logger 0.9.3",
+ "env_logger 0.10.2",
  "eth_trie",
  "ethportal-api",
  "glados-core",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2438,7 +2438,7 @@ dependencies = [
  "clap 4.5.4",
  "enr",
  "entity",
- "env_logger 0.9.3",
+ "env_logger 0.10.2",
  "ethportal-api",
  "glados-core",
  "itertools 0.10.5",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1725,7 +1725,7 @@ dependencies = [
  "migration",
  "pgtemp",
  "rand",
- "rstest 0.16.0",
+ "rstest",
  "sea-orm",
  "sea-query",
  "serde",
@@ -1740,19 +1740,6 @@ checksum = "a19187fea3ac7e84da7dacf48de0c45d63c6a76f9490dae389aead16c243fce3"
 dependencies = [
  "log",
  "regex",
-]
-
-[[package]]
-name = "env_logger"
-version = "0.9.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a12e6657c4c97ebab115a42dcee77225f7f482cdd841cf7088c657a42e9e00e7"
-dependencies = [
- "atty",
- "humantime",
- "log",
- "regex",
- "termcolor",
 ]
 
 [[package]]
@@ -2390,10 +2377,10 @@ dependencies = [
  "anyhow",
  "chrono",
  "entity",
- "env_logger 0.9.3",
+ "env_logger 0.10.2",
  "ethportal-api",
  "jsonrpsee",
- "rstest 0.11.0",
+ "rstest",
  "sea-orm",
  "serde",
  "serde_json",
@@ -4301,19 +4288,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3b241d2e59b74ef9e98d94c78c47623d04c8392abaf82014dfd372a16041128f"
 dependencies = [
  "sha2",
-]
-
-[[package]]
-name = "rstest"
-version = "0.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2288c66aeafe3b2ed227c981f364f9968fa952ef0b30e84ada4486e7ee24d00a"
-dependencies = [
- "cfg-if",
- "proc-macro2",
- "quote",
- "rustc_version 0.4.0",
- "syn 1.0.109",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2412,7 +2412,7 @@ dependencies = [
  "chrono",
  "clap 4.5.4",
  "entity",
- "env_logger 0.9.3",
+ "env_logger 0.10.2",
  "ethportal-api",
  "futures",
  "glados-core",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,6 +24,7 @@ alloy-primitives = "0.7.0"
 anyhow = "1.0.68"
 chrono = "0.4.23"
 clap = { version = "4.0.26", features = ["derive"] }
+enr = "0.10.0"
 entity = { path = "entity" }
 env_logger = "0.10.0"
 ethportal-api = { git = "https://github.com/ethereum/trin" }
@@ -33,8 +34,9 @@ glados-audit = { path = "glados-audit" }
 glados-web = { path = "glados-web" }
 migration = { path = "migration" }
 sea-orm = "0.11.3"
+serde = "1.0.167"
 serde_json = "1.0.95"
-tokio = "1.21.2"
+tokio = "1.22.0"
 tracing = "0.1.37"
 url = "2.3.1"
 web3 = "0.18.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,10 +20,21 @@ migration.workspace = true
 tokio = { workspace = true, features = ["full"] }
 
 [workspace.dependencies]
+alloy-primitives = "0.7.0"
+anyhow = "1.0.68"
+chrono = "0.4.23"
+clap = { version = "4.0.26", features = ["derive"] }
 entity = { path = "entity" }
+env_logger = "0.10.0"
+ethportal-api = { git = "https://github.com/ethereum/trin" }
 glados-core = { path = "glados-core" }
 glados-monitor = { path = "glados-monitor" }
 glados-audit = { path = "glados-audit" }
 glados-web = { path = "glados-web" }
 migration = { path = "migration" }
+sea-orm = "0.11.3"
+serde_json = "1.0.95"
 tokio = "1.21.2"
+tracing = "0.1.37"
+url = "2.3.1"
+web3 = "0.18.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,6 +33,8 @@ glados-monitor = { path = "glados-monitor" }
 glados-audit = { path = "glados-audit" }
 glados-web = { path = "glados-web" }
 migration = { path = "migration" }
+pgtemp = "0.2.1"
+rand = "0.8.5"
 sea-orm = "0.11.3"
 serde = "1.0.167"
 serde_json = "1.0.95"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,10 +11,19 @@ members = [".", "glados-cartographer", "glados-core", "glados-web", "glados-moni
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
+entity.workspace = true
+glados-core.workspace = true
+glados-monitor.workspace = true
+glados-audit.workspace = true
+glados-web.workspace = true
+migration.workspace = true
+tokio = { workspace = true, features = ["full"] }
+
+[workspace.dependencies]
 entity = { path = "entity" }
 glados-core = { path = "glados-core" }
 glados-monitor = { path = "glados-monitor" }
 glados-audit = { path = "glados-audit" }
 glados-web = { path = "glados-web" }
 migration = { path = "migration" }
-tokio = { version = "1", features = ["full"] }
+tokio = "1.21.2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,8 +21,8 @@ tokio = { workspace = true, features = ["full"] }
 
 [workspace.dependencies]
 alloy-primitives = "0.7.0"
-anyhow = "1.0.68"
-chrono = "0.4.23"
+anyhow = "1.0.70"
+chrono = "0.4.24"
 clap = { version = "4.0.26", features = ["derive"] }
 enr = "0.10.0"
 entity = { path = "entity" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,6 +35,7 @@ glados-web = { path = "glados-web" }
 migration = { path = "migration" }
 pgtemp = "0.2.1"
 rand = "0.8.5"
+rstest = "0.16.0"
 sea-orm = "0.11.3"
 serde = "1.0.167"
 serde_json = "1.0.95"

--- a/entity/Cargo.toml
+++ b/entity/Cargo.toml
@@ -9,23 +9,22 @@ authors = ["Piper Merriam <piper@pipermerriam.com>"]
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-alloy-primitives = "0.7.0"
-anyhow = "1.0.68"
-chrono = "0.4.22"
-clap = { version = "4.0.24", features = ["derive"] }
-enr = "0.10.0"
-ethportal-api = { git = "https://github.com/ethereum/trin" }
+alloy-primitives.workspace = true
+anyhow.workspace = true
+chrono.workspace = true
+clap.workspace = true
 discv5 = "0.4.1"
+enr.workspace = true
+env_logger.workspace = true
+ethportal-api.workspace = true
 lazy_static = "1.4.0"
-migration = { path = "../migration" }
-pgtemp = "0.2.1"
-sea-orm = { version = "0.11.3", features = ["sqlx-postgres", "macros", "runtime-tokio-native-tls"] }
+migration.workspace = true
+pgtemp.workspace = true
+rand.workspace = true
+sea-orm = { workspace = true, features = ["sqlx-postgres", "macros", "runtime-tokio-native-tls"] }
 sea-query = "0.28.4"
-tokio = { version = "1.21.2", features = ["macros"] }
-env_logger = "0.10.0"
-rand = "0.8.5"
-rstest = "0.16.0"
-serde = "1.0.167"
+serde.workspace = true
+tokio = { workspace = true, features = ["macros"] }
 
-
-
+[dev-dependencies]
+rstest.workspace = true

--- a/glados-audit/Cargo.toml
+++ b/glados-audit/Cargo.toml
@@ -9,22 +9,22 @@ authors = ["Piper Merriam <piper@pipermerriam.com>"]
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-alloy-primitives = "0.7.0"
-anyhow = "1.0.68"
-chrono = "0.4.23"
-clap = { version = "4.0.24", features = ["derive"] }
-entity = { path = "../entity" }
-env_logger = "0.9.3"
-pgtemp = "0.2.1"
-enr = "0.10.0"
+alloy-primitives.workspace = true
+anyhow.workspace = true
+chrono.workspace= true
+clap.workspace = true
+entity.workspace = true
+env_logger.workspace= true
+pgtemp.workspace = true
+enr.workspace = true
 eth_trie = { git = "https://github.com/kolbyml/eth-trie.rs.git", rev = "7e57d3dfadee126cc9fda2696fb039bf7b6ed688" }
-web3 = "0.18.0"
-ethportal-api = { git = "https://github.com/ethereum/trin" }
-glados-core = { path = "../glados-core" }
-migration = { path = "../migration" }
-rand = "0.8.5"
-sea-orm = "0.11.3"
-serde_json = "1.0.95"
-tokio = "1.21.2"
-tracing = "0.1.37"
-url = "2.3.1"
+web3.workspace= true
+ethportal-api.workspace = true
+glados-core.workspace = true
+migration.workspace = true
+rand.workspace = true
+sea-orm.workspace = true
+serde_json.workspace= true
+tokio.workspace = true
+tracing.workspace = true
+url.workspace = true

--- a/glados-cartographer/Cargo.toml
+++ b/glados-cartographer/Cargo.toml
@@ -6,17 +6,17 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-alloy-primitives = "0.7.0"
-anyhow = "1.0.70"
-clap = { version = "4.0.24", features = ["derive"] }
-glados-core = { path = "../glados-core" }
-migration = { path = "../migration" }
-entity = { path = "../entity" }
-env_logger = "0.10.0"
-enr = "0.10.0"
-ethportal-api = { git = "https://github.com/ethereum/trin" }
-sea-orm = "0.11.3"
-tokio = { version = "1.27.0", features = ["signal"] }
-tracing = "0.1.37"
-url = "2.3.1"
-chrono = "0.4.24"
+alloy-primitives.workspace = true
+anyhow.workspace = true
+chrono.workspace = true
+clap.workspace = true
+entity.workspace = true
+enr.workspace = true
+env_logger.workspace = true
+ethportal-api.workspace = true
+glados-core.workspace = true
+migration.workspace = true
+sea-orm.workspace = true
+tokio = { workspace = true, features = ["signal"] }
+tracing.workspace = true
+url.workspace = true

--- a/glados-core/Cargo.toml
+++ b/glados-core/Cargo.toml
@@ -9,20 +9,20 @@ authors = ["Piper Merriam <piper@pipermerriam.com>"]
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-alloy-primitives = "0.7.0"
-anyhow = "1.0.68"
-chrono = "0.4.22"
-entity = { path = "../entity" }
-sea-orm = "0.11.3"
-serde = "1.0.147"
-serde_json = "1.0.87"
+alloy-primitives.workspace = true
+anyhow.workspace = true
+chrono.workspace = true
+entity.workspace = true
+env_logger.workspace = true
+ethportal-api.workspace = true
+jsonrpsee = { version = "0.20.0", features = ["async-client", "client"] }
+sea-orm.workspace = true
+serde.workspace = true
+serde_json.workspace = true
 sha2 = "0.10.6"
 thiserror = "1.0.37"
-env_logger = "0.9.3"
-tracing = "0.1.37"
-ethportal-api = { git = "https://github.com/ethereum/trin" }
-url = "2.3.1"
-jsonrpsee = { version = "0.20.0", features = ["async-client", "client"] }
+tracing.workspace = true
+url.workspace = true
 
 [dev-dependencies]
-rstest = "0.11.0"
+rstest.workspace = true

--- a/glados-monitor/Cargo.toml
+++ b/glados-monitor/Cargo.toml
@@ -9,20 +9,20 @@ authors = ["Piper Merriam <piper@pipermerriam.com>"]
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-alloy-primitives = "0.7.0"
-anyhow = "1.0.68"
-glados-core = { path = "../glados-core" }
-migration = { path = "../migration" }
-chrono = "0.4.22"
-entity = { path = "../entity" }
-clap = { version = "4.0.24", features = ["derive"] }
-web3 = "0.18.0"
-tokio = "1.21.2"
-sea-orm = "0.11.3"
-env_logger = "0.9.3"
+alloy-primitives.workspace = true
+anyhow.workspace = true
+clap.workspace = true
+chrono.workspace = true
+entity.workspace = true
+env_logger.workspace = true
+ethportal-api.workspace = true
 futures = "0.3.21"
-serde_json = "1.0.89"
-tracing = "0.1.37"
-ethportal-api = { git = "https://github.com/ethereum/trin" }
+glados-core.workspace = true
+migration.workspace = true
 reqwest = { version = "0.11.6", default-features = false, features = ["rustls-tls"] }
-url = "2.2.2"
+sea-orm.workspace = true
+serde_json.workspace = true
+tokio.workspace = true
+tracing.workspace = true
+url.workspace = true
+web3.workspace = true

--- a/glados-web/Cargo.toml
+++ b/glados-web/Cargo.toml
@@ -9,21 +9,21 @@ authors = ["Piper Merriam <piper@pipermerriam.com>"]
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-alloy-primitives = "0.7.0"
-anyhow = "1.0.68"
+alloy-primitives.workspace = true
+anyhow.workspace = true
 askama = { version = "0.11.1", features = ["serde-json"] }
 axum = "0.6.11"
-chrono = "0.4.23"
-clap = { version = "4.0.26", features = ["derive"] }
-entity = { path = "../entity" }
-env_logger = "0.9.3"
-ethportal-api = { git = "https://github.com/ethereum/trin" }
-enr = "0.10.0"
-glados-core = { path = "../glados-core" }
-migration = { path = "../migration" }
+chrono.workspace = true
+clap.workspace = true
+enr.workspace = true
+entity.workspace = true
+env_logger.workspace = true
+ethportal-api.workspace = true
+glados-core.workspace = true
 itertools = "0.10.5"
-sea-orm = "0.11.3"
-serde = "1.0.167"
-tokio = "1.22.0"
+migration.workspace = true
+sea-orm.workspace = true
+serde.workspace = true
+tokio.workspace = true
 tower-http = { version = "0.3.5", features = ["fs"] }
-tracing = "0.1.37"
+tracing.workspace = true


### PR DESCRIPTION
Updating dependencies, like in https://github.com/ethereum/trin/issues/845

I also alphabetized, when I noticed it. I would love to use cargo-sort, but apparently it's not compatible with workspace dependencies.