### PR TITLE
feat: adds dashboard census-feature parity across beacon, history, state networks 

### DIFF
--- a/docker-compose-clients.yml
+++ b/docker-compose-clients.yml
@@ -3,7 +3,7 @@ services:
     image: portalnetwork/trin:latest
     environment:
       RUST_LOG: info
-    command: "--web3-transport http --web3-http-address http://0.0.0.0:8545/ --mb 0 --no-upnp --disable-poke ${GLADOS_CLIENT_ARGUMENTS:-}"
+    command: "--web3-transport http --web3-http-address http://0.0.0.0:8545/ --mb 0 --portal-subnetworks history,state,beacon --no-upnp --disable-poke ${GLADOS_CLIENT_ARGUMENTS:-}"
   fluffy:
     image: statusim/nimbus-fluffy:amd64-master-latest
     command: "--rpc --rpc-address=0.0.0.0 --storage-capacity=0 --disable-poke ${GLADOS_CLIENT_ARGUMENTS:-}"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -63,8 +63,38 @@ services:
       - glados-net
     restart: always
 
-  glados_cartographer:
+  glados_cartographer_history:
     command: "--database-url postgres://postgres:${GLADOS_POSTGRES_PASSWORD}@glados_postgres:5432/glados --transport http --http-url http://host.docker.internal:8545 --concurrency 10 --subnetwork history"
+    image: portalnetwork/glados-cartographer:latest
+    environment:
+      RUST_LOG: warn,glados_cartographer=info
+    depends_on:
+      - glados_web
+      - glados_postgres
+      - portal_client
+    networks:
+      - glados-net
+    extra_hosts:
+      - "host.docker.internal:host-gateway"
+    restart: always
+
+  glados_cartographer_state:
+    command: "--database-url postgres://postgres:${GLADOS_POSTGRES_PASSWORD}@glados_postgres:5432/glados --transport http --http-url http://host.docker.internal:8545 --concurrency 10 --subnetwork state"
+    image: portalnetwork/glados-cartographer:latest
+    environment:
+      RUST_LOG: warn,glados_cartographer=info
+    depends_on:
+      - glados_web
+      - glados_postgres
+      - portal_client
+    networks:
+      - glados-net
+    extra_hosts:
+      - "host.docker.internal:host-gateway"
+    restart: always
+
+  glados_cartographer_beacon:
+    command: "--database-url postgres://postgres:${GLADOS_POSTGRES_PASSWORD}@glados_postgres:5432/glados --transport http --http-url http://host.docker.internal:8545 --concurrency 10 --subnetwork beacon"
     image: portalnetwork/glados-cartographer:latest
     environment:
       RUST_LOG: warn,glados_cartographer=info

--- a/entity/src/test.rs
+++ b/entity/src/test.rs
@@ -277,7 +277,7 @@ async fn test_content_table_unique_constraints() {
         id: NotSet,
         content_id: Set(id_a.clone()),
         content_key: Set(key_a.clone()),
-        protocol_id: Set(protocol_a.clone()),
+        protocol_id: Set(protocol_a),
         first_available_at: Set(Utc::now()),
     };
     action_a.clone().insert(&conn).await.unwrap();
@@ -318,7 +318,7 @@ async fn test_content_table_unique_constraints() {
         id: NotSet,
         content_id: Set(id_b),
         content_key: Set(key_a),
-        protocol_id: Set(protocol_a.clone()),
+        protocol_id: Set(protocol_a),
         first_available_at: Set(Utc::now()),
     };
     assert!(action_c

--- a/glados-web/assets/js/censustimeseries.js
+++ b/glados-web/assets/js/censustimeseries.js
@@ -65,8 +65,10 @@ function createSquareChart(width, data) {
         .attr("style", "max-width: 90%; height: 100%; height: intrinsic;");
 
 
-    let title = data.censuses.length > 0 ? `${nodes.length} nodes found during 24 hour period beginning at ${data.censuses[0].time}`
-        : `No censuses found during this 24 hour period.`;
+    const url = new URL(window.location);
+    const subprotocol = url.searchParams.get('network');
+    let title = data.censuses.length > 0 ? `${nodes.length} ${subprotocol} nodes found during 24 hour period beginning at ${data.censuses[0].time}`
+        : `No ${subprotocol} censuses found during this 24 hour period.`;
     
     // Append the title
     svg.append("text")
@@ -360,9 +362,9 @@ function getClientStringFromDecodedEnr(decodedEnr) {
 }
 
 // Fetch the census node records from the API.
-async function getCensusTimeSeriesData(numDaysAgo) {
+async function getCensusTimeSeriesData(numDaysAgo, subprotocol) {
 
-    const baseUrl = `census-node-timeseries-data/?days-ago=${numDaysAgo}`;
+    const baseUrl = `census-node-timeseries-data/?days-ago=${numDaysAgo}&network=${subprotocol}`;
     return fetch(`${baseUrl}`)
         .then(response => {
             if (!response.ok) {
@@ -381,18 +383,20 @@ async function censusTimeSeriesChart(daysAgo) {
         svgElement.remove();
     });
 
-    const data = await getCensusTimeSeriesData(daysAgo);
+    const url = new URL(window.location);
+    subprotocol = url.searchParams.get('network');
+
+    const data = await getCensusTimeSeriesData(daysAgo, subprotocol);
     console.log('Census data from glados API:');
     console.log(data);
     if (data) {
         document.getElementById('census-timeseries-graph').appendChild(createSquareChart(1700, data));
-        if (navigator.userAgent.toLowerCase().indexOf('firefox') > -1) {
-            alert('This page does not display well on Firefox, Chrome or Safari are recommended.');
-        }
     } else {
         console.log('No data available to plot the census chart');
     }
 }
+
+// Sort nodes by nickname, latestClientString, and nodeId
 function sortNodes(a, b) {
 
     // Check for "bootnode" in nodeNickName

--- a/glados-web/assets/js/stats_history.js
+++ b/glados-web/assets/js/stats_history.js
@@ -274,10 +274,8 @@ function getStatsRecords(weeksAgo) {
 
 async function updateChart(weeksAgo) {
     const data = await getStatsRecords(weeksAgo);
-    console.log(data);
 
     let dataSets = convertDataForChart(data);
-    console.log(dataSets);
 
     // Clear the existing chart
     d3.select("#stats-history-graph").html("");

--- a/glados-web/src/lib.rs
+++ b/glados-web/src/lib.rs
@@ -62,7 +62,7 @@ pub async fn run_glados_web(config: Arc<State>) -> Result<()> {
 
     // setup router
     let app = Router::new()
-        .route("/", get(routes::root))
+        .route("/", get(routes::network_overview))
         .route("/census/census-list/", get(routes::census_explorer_list))
         .route("/census/", get(routes::single_census_view))
         .route("/census/explorer", get(routes::census_explorer))

--- a/glados-web/templates/base.html
+++ b/glados-web/templates/base.html
@@ -17,28 +17,71 @@
 <body>
 
     <nav class="navbar navbar-expand-lg navbar-light" style="background-color: #ffffff;">
-        <div>
-            <button class="navbar-toggler" type="button" data-bs-toggle="collapse"
-                data-bs-target="#navbarSupportedContent" aria-controls="navbarSupportedContent" aria-expanded="false"
-                aria-label="Toggle navigation">
-                <span class="navbar-toggler-icon"></span>
-            </button>
+        <div class="container-fluid">
             <div class="collapse navbar-collapse" id="navbarSupportedContent">
                 <ul class="navbar-nav me-auto">
-                    <a class="nav-link active" style="margin-left: 20px;" href="/">Glados</a>
                     <li class="nav-item">
-                        <a class="nav-link active" aria-current="page" style="margin-left: 20px;" href="/audits/">Audit
-                            Dashboard</a>
+                        <a class="nav-link active" style="margin-left: 20px;" href="/">Glados</a>
                     </li>
                     <li class="nav-item">
-                        <a class="nav-link active" aria-current="page" style="margin-left: 20px;"
-                           href="/census/explorer">Census Explorer</a>
+                        <a class="nav-link active" aria-current="page" style="margin-left: 20px;" href="/audits/">Audit Dashboard</a>
+                    </li>
+                    <li class="nav-item">
+                        <a class="nav-link active" aria-current="page" style="margin-left: 20px;" href="/census/explorer">Census Explorer</a>
                     </li>
                 </ul>
+                <select name="network-selector" id="network-selector" class="form-select" style="width: auto;">
+                    <option value="history">History</option>
+                    <option value="state">State</option>
+                    <option value="beacon">Beacon</option>
+                </select>
             </div>
         </div>
     </nav>
     <hr style="margin-top: 0;">
+    <script>
+        // Logic for managing syncing network selector & URL parameter
+        document.addEventListener('DOMContentLoaded', function() {
+            const networkSelector = document.getElementById('network-selector');
+            
+            function syncSelectorWithUrl() {
+                const urlParams = new URLSearchParams(window.location.search);
+                const networkParam = urlParams.get('network');
+                if (networkParam && networkSelector.querySelector(`option[value="${networkParam}"]`)) {
+                    networkSelector.value = networkParam;
+                }
+            }
+
+            function loadNewUrl() {
+                const selectedValue = networkSelector.value;
+                const url = new URL(window.location);
+                url.searchParams.set('network', selectedValue);
+                window.location.href = url.toString();
+            }
+
+            function appendNetworkToUrl(url) {
+                const networkValue = networkSelector.value;
+                const urlObj = new URL(url, window.location.origin);
+                urlObj.searchParams.set('network', networkValue);
+                return urlObj.toString();
+            }
+
+            // Set initial value based on URL parameter.
+            syncSelectorWithUrl();
+
+            // Load new URL when selector changes.
+            networkSelector.addEventListener('change', loadNewUrl);
+
+            // Update link clicks to include network selector parameter.
+            document.body.addEventListener('click', function(e) {
+                const target = e.target.closest('a');
+                if (target && target.href && target.host === window.location.host) {
+                    e.preventDefault();
+                    window.location.href = appendNetworkToUrl(target.href);
+                }
+            });
+        });
+    </script>
 
     <div id="content">
         <div id="container">

--- a/glados-web/templates/index.html
+++ b/glados-web/templates/index.html
@@ -145,9 +145,6 @@
     radius_node_id_scatter_chart(census_data);
     radius_stacked_chart(census_data);
     statsHistoryChart();
-
-    
-
 </script>
 
 {% endblock %}

--- a/migration/src/lib.rs
+++ b/migration/src/lib.rs
@@ -14,6 +14,7 @@ mod m20240322_205213_add_content_audit_index;
 mod m20240515_064320_state_roots;
 mod m20240720_111606_create_census_index;
 mod m20240814_121507_census_subnetwork;
+mod m20240919_121611_census_subnetwork_index;
 
 pub struct Migrator;
 
@@ -35,6 +36,7 @@ impl MigratorTrait for Migrator {
             Box::new(m20240515_064320_state_roots::Migration),
             Box::new(m20240720_111606_create_census_index::Migration),
             Box::new(m20240814_121507_census_subnetwork::Migration),
+            Box::new(m20240919_121611_census_subnetwork_index::Migration),
         ]
     }
 }

--- a/migration/src/m20240814_121507_census_subnetwork.rs
+++ b/migration/src/m20240814_121507_census_subnetwork.rs
@@ -3,6 +3,9 @@ use sea_orm_migration::prelude::*;
 #[derive(DeriveMigrationName)]
 pub struct Migration;
 
+const INDEX_CENSUS_SUBNET_INDEX: &str = "idx_census_subnet";
+const INDEX_CENSUS_NODE_SUBNET_INDEX: &str = "idx_census_node_subnet";
+
 #[async_trait::async_trait]
 impl MigrationTrait for Migration {
     async fn up(&self, manager: &SchemaManager) -> Result<(), DbErr> {
@@ -16,13 +19,31 @@ impl MigrationTrait for Migration {
                     .to_owned(),
             )
             .await;
-        manager
+        let _ = manager
+            .create_index(
+                Index::create()
+                    .name(INDEX_CENSUS_SUBNET_INDEX)
+                    .table(Census::Table)
+                    .col(Census::SubNetwork)
+                    .to_owned(),
+            )
+            .await;
+        let _ = manager
             .alter_table(
                 Table::alter()
                     .table(CensusNode::Table)
                     .add_column_if_not_exists(
                         ColumnDef::new(CensusNode::SubNetwork).unsigned().default(0),
                     )
+                    .to_owned(),
+            )
+            .await;
+        manager
+            .create_index(
+                Index::create()
+                    .name(INDEX_CENSUS_NODE_SUBNET_INDEX)
+                    .table(CensusNode::Table)
+                    .col(CensusNode::SubNetwork)
                     .to_owned(),
             )
             .await

--- a/migration/src/m20240919_121611_census_subnetwork_index.rs
+++ b/migration/src/m20240919_121611_census_subnetwork_index.rs
@@ -3,27 +3,27 @@ use sea_orm_migration::prelude::*;
 #[derive(DeriveMigrationName)]
 pub struct Migration;
 
+const INDEX_CENSUS_SUBNET_INDEX: &str = "idx_census_subnet";
+const INDEX_CENSUS_NODE_SUBNET_INDEX: &str = "idx_census_node_subnet";
+
 #[async_trait::async_trait]
 impl MigrationTrait for Migration {
     async fn up(&self, manager: &SchemaManager) -> Result<(), DbErr> {
         let _ = manager
-            .alter_table(
-                Table::alter()
+            .create_index(
+                Index::create()
+                    .name(INDEX_CENSUS_SUBNET_INDEX)
                     .table(Census::Table)
-                    .add_column_if_not_exists(
-                        ColumnDef::new(Census::SubNetwork).unsigned().default(0),
-                    )
+                    .col(Census::SubNetwork)
                     .to_owned(),
             )
             .await;
-
         manager
-            .alter_table(
-                Table::alter()
+            .create_index(
+                Index::create()
+                    .name(INDEX_CENSUS_NODE_SUBNET_INDEX)
                     .table(CensusNode::Table)
-                    .add_column_if_not_exists(
-                        ColumnDef::new(CensusNode::SubNetwork).unsigned().default(0),
-                    )
+                    .col(CensusNode::SubNetwork)
                     .to_owned(),
             )
             .await
@@ -31,18 +31,12 @@ impl MigrationTrait for Migration {
 
     async fn down(&self, manager: &SchemaManager) -> Result<(), DbErr> {
         let _ = manager
-            .alter_table(
-                Table::alter()
-                    .table(Census::Table)
-                    .drop_column(Census::SubNetwork)
-                    .to_owned(),
-            )
+            .drop_index(Index::drop().name(INDEX_CENSUS_SUBNET_INDEX).to_owned())
             .await;
         manager
-            .alter_table(
-                Table::alter()
-                    .table(Census::Table)
-                    .drop_column(Census::SubNetwork)
+            .drop_index(
+                Index::drop()
+                    .name(INDEX_CENSUS_NODE_SUBNET_INDEX)
                     .to_owned(),
             )
             .await


### PR DESCRIPTION
Glados currently only gathers and displays census data for the history network. This PR:

- turns on state and beacon networks on glados's trin instance
- runs cartographer instances for state and beacon networks to gather census data
- adds a selector to the UI that filters and displays census data by network: history, state, or beacon, while filtering via an http param `?network=` on the backend.

Bonus: continues the migration toward raw SQL and simplifies the calls for readability and maintenance purposes. 

Implements #293 for census data.

Note that all audit data will still show history, which is a bit awkward (history audit data displayed next to beacon/state census data) but it will toggle audit data per network in the next PR.

![Screenshot 2024-09-19 at 12 31 08 PM](https://github.com/user-attachments/assets/84aa0cec-bfe2-4a12-9425-d6f4e46d29ba)

