### PR TITLE
fix: allow census to conclude if zero nodes are found

### DIFF
--- a/glados-cartographer/src/lib.rs
+++ b/glados-cartographer/src/lib.rs
@@ -144,8 +144,10 @@ impl DHTCensus {
         let finished = self.finished.read().await.len();
         let errored = self.errored.read().await.len();
 
-        if known == 0 {
+        if known == 0 && self.duration().num_seconds() < 60 {
             false
+        } else if known == 0 {
+            true
         } else {
             errored + finished == known
         }


### PR DESCRIPTION
If `glados_cartographer` finds zero nodes it will run the census forever.

History census recently deadlocked mysteriously, which I now believe happened because of this. Trin may have been restarted and the census was initialized before the trin node had anything in its routing table.

Additionally, beacon network currently has zero nodes on it, so one single census will run forever. This change makes it so that censuses will continually run and pick up new nodes as they come online.