### PR TITLE
feat: adds state audits & audit dashboard state filtering

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -37,8 +37,34 @@ services:
       - "host.docker.internal:host-gateway"
     restart: always
 
+  glados_audit_state:
+    command: "--database-url postgres://postgres:${GLADOS_POSTGRES_PASSWORD}@glados_postgres:5432/glados --portal-client http://host.docker.internal:8545 --state --history=false"
+    image: portalnetwork/glados-audit:latest
+    environment:
+      RUST_LOG: warn,glados_audit=info
+    depends_on:
+      - glados_postgres
+      - portal_client
+    networks:
+      - glados-net
+    extra_hosts:
+      - "host.docker.internal:host-gateway"
+    restart: always
+
   glados_monitor:
     command: "--database-url postgres://postgres:${GLADOS_POSTGRES_PASSWORD}@glados_postgres:5432/glados follow-head --provider-url ${GLADOS_PROVIDER_URL?Glados monitor provider URL required}"
+    image: portalnetwork/glados-monitor:latest
+    environment:
+      RUST_LOG: warn,glados_monitor=info
+    depends_on:
+      - glados_audit
+      - glados_postgres
+    networks:
+      - glados-net
+    restart: always
+
+  glados_monitor_state:
+    command: "--database-url postgres://postgres:${GLADOS_POSTGRES_PASSWORD}@glados_postgres:5432/glados populate-state-roots-range --provider-url ${GLADOS_PROVIDER_URL?Glados monitor provider URL required} --start-block-number 0 --end-block-number 1000001"
     image: portalnetwork/glados-monitor:latest
     environment:
       RUST_LOG: warn,glados_monitor=info

--- a/entity/src/content.rs
+++ b/entity/src/content.rs
@@ -6,9 +6,10 @@ use chrono::{DateTime, Utc};
 use ethportal_api::utils::bytes::{hex_encode, hex_encode_compact};
 use ethportal_api::OverlayContentKey;
 use sea_orm::{entity::prelude::*, ActiveValue::NotSet, Set};
+use serde::Deserialize;
 
 /// Portal network sub-protocol. History, state, transactions etc.
-#[derive(Debug, Clone, Copy, Eq, PartialEq, EnumIter, DeriveActiveEnum)]
+#[derive(Debug, Clone, Copy, Eq, PartialEq, EnumIter, DeriveActiveEnum, Deserialize)]
 #[sea_orm(rs_type = "i32", db_type = "Integer")]
 pub enum SubProtocol {
     History = 0,

--- a/glados-audit/src/stats.rs
+++ b/glados-audit/src/stats.rs
@@ -1,5 +1,5 @@
 use chrono::Utc;
-use entity::audit_stats;
+use entity::{audit_stats, content::SubProtocol};
 use glados_core::stats::{
     filter_audits, get_audit_stats, AuditFilters, ContentTypeFilter, Period, StrategyFilter,
     SuccessFilter,
@@ -47,8 +47,9 @@ async fn record_current_stats(conn: &DatabaseConnection) -> Result<(), DbErr> {
             filter_audits(AuditFilters {
                 strategy: StrategyFilter::All,
                 content_type: ContentTypeFilter::All,
-                success: SuccessFilter::All
-            }),
+                success: SuccessFilter::All,
+                network: SubProtocol::History
+            },),
             Period::Hour,
             conn
         ),
@@ -56,8 +57,9 @@ async fn record_current_stats(conn: &DatabaseConnection) -> Result<(), DbErr> {
             filter_audits(AuditFilters {
                 strategy: StrategyFilter::Latest,
                 content_type: ContentTypeFilter::All,
-                success: SuccessFilter::All
-            }),
+                success: SuccessFilter::All,
+                network: SubProtocol::History
+            },),
             Period::Hour,
             conn
         ),
@@ -65,8 +67,9 @@ async fn record_current_stats(conn: &DatabaseConnection) -> Result<(), DbErr> {
             filter_audits(AuditFilters {
                 strategy: StrategyFilter::Random,
                 content_type: ContentTypeFilter::All,
-                success: SuccessFilter::All
-            }),
+                success: SuccessFilter::All,
+                network: SubProtocol::History
+            },),
             Period::Hour,
             conn
         ),
@@ -74,8 +77,9 @@ async fn record_current_stats(conn: &DatabaseConnection) -> Result<(), DbErr> {
             filter_audits(AuditFilters {
                 strategy: StrategyFilter::FourFours,
                 content_type: ContentTypeFilter::All,
-                success: SuccessFilter::All
-            }),
+                success: SuccessFilter::All,
+                network: SubProtocol::History
+            },),
             Period::Hour,
             conn
         ),
@@ -83,8 +87,9 @@ async fn record_current_stats(conn: &DatabaseConnection) -> Result<(), DbErr> {
             filter_audits(AuditFilters {
                 strategy: StrategyFilter::All,
                 content_type: ContentTypeFilter::Headers,
-                success: SuccessFilter::All
-            }),
+                success: SuccessFilter::All,
+                network: SubProtocol::History
+            },),
             Period::Hour,
             conn
         ),
@@ -92,8 +97,9 @@ async fn record_current_stats(conn: &DatabaseConnection) -> Result<(), DbErr> {
             filter_audits(AuditFilters {
                 strategy: StrategyFilter::All,
                 content_type: ContentTypeFilter::Bodies,
-                success: SuccessFilter::All
-            }),
+                success: SuccessFilter::All,
+                network: SubProtocol::History
+            },),
             Period::Hour,
             conn
         ),
@@ -101,8 +107,9 @@ async fn record_current_stats(conn: &DatabaseConnection) -> Result<(), DbErr> {
             filter_audits(AuditFilters {
                 strategy: StrategyFilter::All,
                 content_type: ContentTypeFilter::Receipts,
-                success: SuccessFilter::All
-            }),
+                success: SuccessFilter::All,
+                network: SubProtocol::History
+            },),
             Period::Hour,
             conn
         ),
@@ -110,8 +117,9 @@ async fn record_current_stats(conn: &DatabaseConnection) -> Result<(), DbErr> {
             filter_audits(AuditFilters {
                 strategy: StrategyFilter::Latest,
                 content_type: ContentTypeFilter::Headers,
-                success: SuccessFilter::All
-            }),
+                success: SuccessFilter::All,
+                network: SubProtocol::History
+            },),
             Period::Hour,
             conn
         ),
@@ -119,8 +127,9 @@ async fn record_current_stats(conn: &DatabaseConnection) -> Result<(), DbErr> {
             filter_audits(AuditFilters {
                 strategy: StrategyFilter::Latest,
                 content_type: ContentTypeFilter::Bodies,
-                success: SuccessFilter::All
-            }),
+                success: SuccessFilter::All,
+                network: SubProtocol::History
+            },),
             Period::Hour,
             conn
         ),
@@ -128,8 +137,9 @@ async fn record_current_stats(conn: &DatabaseConnection) -> Result<(), DbErr> {
             filter_audits(AuditFilters {
                 strategy: StrategyFilter::Latest,
                 content_type: ContentTypeFilter::Receipts,
-                success: SuccessFilter::All
-            }),
+                success: SuccessFilter::All,
+                network: SubProtocol::History
+            },),
             Period::Hour,
             conn
         ),
@@ -137,8 +147,9 @@ async fn record_current_stats(conn: &DatabaseConnection) -> Result<(), DbErr> {
             filter_audits(AuditFilters {
                 strategy: StrategyFilter::Random,
                 content_type: ContentTypeFilter::Headers,
-                success: SuccessFilter::All
-            }),
+                success: SuccessFilter::All,
+                network: SubProtocol::History
+            },),
             Period::Hour,
             conn
         ),
@@ -146,8 +157,9 @@ async fn record_current_stats(conn: &DatabaseConnection) -> Result<(), DbErr> {
             filter_audits(AuditFilters {
                 strategy: StrategyFilter::Random,
                 content_type: ContentTypeFilter::Bodies,
-                success: SuccessFilter::All
-            }),
+                success: SuccessFilter::All,
+                network: SubProtocol::History
+            },),
             Period::Hour,
             conn
         ),
@@ -155,8 +167,9 @@ async fn record_current_stats(conn: &DatabaseConnection) -> Result<(), DbErr> {
             filter_audits(AuditFilters {
                 strategy: StrategyFilter::Random,
                 content_type: ContentTypeFilter::Receipts,
-                success: SuccessFilter::All
-            }),
+                success: SuccessFilter::All,
+                network: SubProtocol::History
+            },),
             Period::Hour,
             conn
         ),
@@ -164,8 +177,9 @@ async fn record_current_stats(conn: &DatabaseConnection) -> Result<(), DbErr> {
             filter_audits(AuditFilters {
                 strategy: StrategyFilter::FourFours,
                 content_type: ContentTypeFilter::Headers,
-                success: SuccessFilter::All
-            }),
+                success: SuccessFilter::All,
+                network: SubProtocol::History
+            },),
             Period::Hour,
             conn
         ),
@@ -173,8 +187,9 @@ async fn record_current_stats(conn: &DatabaseConnection) -> Result<(), DbErr> {
             filter_audits(AuditFilters {
                 strategy: StrategyFilter::FourFours,
                 content_type: ContentTypeFilter::Bodies,
-                success: SuccessFilter::All
-            }),
+                success: SuccessFilter::All,
+                network: SubProtocol::History
+            },),
             Period::Hour,
             conn
         ),
@@ -182,8 +197,9 @@ async fn record_current_stats(conn: &DatabaseConnection) -> Result<(), DbErr> {
             filter_audits(AuditFilters {
                 strategy: StrategyFilter::FourFours,
                 content_type: ContentTypeFilter::Receipts,
-                success: SuccessFilter::All
-            }),
+                success: SuccessFilter::All,
+                network: SubProtocol::History
+            },),
             Period::Hour,
             conn
         )

--- a/glados-web/src/routes.rs
+++ b/glados-web/src/routes.rs
@@ -87,31 +87,33 @@ pub async fn network_overview(
             filter_audits(AuditFilters {
                 strategy: StrategyFilter::FourFours,
                 content_type: ContentTypeFilter::All,
-                success: SuccessFilter::All
-            }),
+                success: SuccessFilter::All,
+                network: subprotocol,
+            },),
             Period::Hour,
-            &state.database_connection
+            &state.database_connection,
         ),
         get_audit_stats(
             filter_audits(AuditFilters {
                 strategy: StrategyFilter::FourFours,
                 content_type: ContentTypeFilter::All,
-                success: SuccessFilter::All
-            }),
+                success: SuccessFilter::All,
+                network: subprotocol,
+            },),
             Period::Day,
-            &state.database_connection
+            &state.database_connection,
         ),
         get_audit_stats(
             filter_audits(AuditFilters {
                 strategy: StrategyFilter::FourFours,
                 content_type: ContentTypeFilter::All,
-                success: SuccessFilter::All
-            }),
+                success: SuccessFilter::All,
+                network: subprotocol,
+            },),
             Period::Week,
-            &state.database_connection
+            &state.database_connection,
         ),
     );
-
     // Get results from queries
     let hour_stats = hour_stats.unwrap();
     let day_stats = day_stats.unwrap();
@@ -424,8 +426,11 @@ pub async fn contentkey_list(
     Ok(HtmlTemplate(template))
 }
 
-pub async fn contentaudit_dashboard() -> Result<HtmlTemplate<AuditDashboardTemplate>, StatusCode> {
-    let template = AuditDashboardTemplate {};
+pub async fn contentaudit_dashboard(
+    params: HttpQuery<HashMap<String, String>>,
+) -> Result<HtmlTemplate<AuditDashboardTemplate>, StatusCode> {
+    let subprotocol = get_subprotocol_from_params(&params);
+    let template = AuditDashboardTemplate { subprotocol };
     Ok(HtmlTemplate(template))
 }
 

--- a/glados-web/src/templates.rs
+++ b/glados-web/src/templates.rs
@@ -3,7 +3,11 @@ use axum::{
     http::StatusCode,
     response::{Html, IntoResponse, Response},
 };
-use entity::{client_info, content, content_audit, execution_metadata, key_value, node, record};
+use entity::{
+    client_info,
+    content::{self, SubProtocol},
+    content_audit, execution_metadata, key_value, node, record,
+};
 
 use crate::routes::{
     CalculatedRadiusChartData, ClientDiversityResult, PaginatedCensusListResult, RawEnr,
@@ -90,7 +94,9 @@ pub struct ContentKeyListTemplate {
 
 #[derive(Template)]
 #[template(path = "audit_dashboard.html")]
-pub struct AuditDashboardTemplate {}
+pub struct AuditDashboardTemplate {
+    pub subprotocol: SubProtocol,
+}
 
 #[derive(Template)]
 #[template(path = "audit_table.html")]

--- a/glados-web/templates/audit_dashboard.html
+++ b/glados-web/templates/audit_dashboard.html
@@ -10,28 +10,50 @@
         <br />
         <h1 class="header text-center">Audit Dashboard</h1>
         <div class="d-flex justify-content-center flex-wrap">
-            <div id="content-buttons" class="btn-group mx-1" role="group">
-                <button id="all-content-button" filter="All" class="btn btn-outline-secondary"
-                    type="button">All</button>
-                <button id="headers-button" filter="Headers" class="btn btn-outline-secondary"
-                    type="button">Headers</button>
-                <button id="bodies-button" filter="Bodies" class="btn btn-outline-secondary"
-                    type="button">Bodies</button>
-                <button id="receipts-button" filter="Receipts" class="btn btn-outline-secondary"
-                    type="button">Receipts</button>
-            </div>
-            <div id="strategy-buttons" class="btn-group mx-1" role="group">
-                <button id="all-strategy-button" filter="All" class="btn btn-outline-secondary"
-                    type="button">All</button>
-                <button id="latest-button" filter="Latest" class="btn btn-outline-secondary"
-                    type="button">Latest</button>
-                <button id="random-button" filter="Random" class="btn btn-outline-secondary"
-                    type="button">Random</button>
-                <button id="oldest-button" filter="Oldest" class="btn btn-outline-secondary" type="button">Oldest
-                    Unaudited</button>
-                <button id="fourfours-button" filter="FourFours" class="btn btn-outline-secondary"
-                    type="button">4444s</button>
-            </div>
+            {% if subprotocol == SubProtocol::History %}
+
+                <div id="content-buttons" class="btn-group mx-1" role="group">
+                    <button id="all-content-button" filter="All" class="btn btn-outline-secondary"
+                        type="button">All</button>
+                    <button id="headers-button" filter="Headers" class="btn btn-outline-secondary"
+                        type="button">Headers</button>
+                    <button id="bodies-button" filter="Bodies" class="btn btn-outline-secondary"
+                        type="button">Bodies</button>
+                    <button id="receipts-button" filter="Receipts" class="btn btn-outline-secondary"
+                        type="button">Receipts</button>
+                </div>
+                <div id="strategy-buttons" class="btn-group mx-1" role="group">
+                    <button id="all-strategy-button" filter="All" class="btn btn-outline-secondary"
+                        type="button">All</button>
+                    <button id="latest-button" filter="Latest" class="btn btn-outline-secondary"
+                        type="button">Latest</button>
+                    <button id="random-button" filter="Random" class="btn btn-outline-secondary"
+                        type="button">Random</button>
+                    <button id="oldest-button" filter="Oldest" class="btn btn-outline-secondary" type="button">Oldest
+                        Unaudited</button>
+                    <button id="fourfours-button" filter="FourFours" class="btn btn-outline-secondary"
+                        type="button">4444s</button>
+                </div>
+
+            {% elseif subprotocol == SubProtocol::State %} 
+
+                <div id="content-buttons" class="btn-group mx-1" role="group">
+                    <button id="all-content-button" filter="All" class="btn btn-outline-secondary"
+                        type="button">All</button>
+                    <button id="random-button" filter="Random" class="btn btn-outline-secondary"
+                        type="button">Random</button>
+                </div>
+
+                <div id="strategy-buttons" class="btn-group mx-1" role="group">
+                    <button id="all-strategy-button" filter="All" class="btn btn-outline-secondary"
+                        type="button">All</button>
+                    <button id="account-trie-button" filter="AccountTrieNodes" class="btn btn-outline-secondary"
+                        type="button">Account Trie Nodes</button>
+                </div>
+
+            {% elseif subprotocol == SubProtocol::Beacon %}
+
+            {% endif %}
             <div id="success-buttons" class="btn-group mx-1 " role="group">
                 <button id="all-success-button" filter="All" class="btn btn-outline-secondary"
                     type="button">All</button>
@@ -123,7 +145,10 @@
     function updateDashboard(strategy, content_type, success) {
 
         const baseUrl = "filter/";
+        const url = new URL(window.location);
+        subprotocol = url.searchParams.get('network');
         const params = {
+            network: subprotocol,
             strategy: strategy,
             content_type: content_type,
             success: success,

--- a/glados-web/templates/base.html
+++ b/glados-web/templates/base.html
@@ -31,9 +31,9 @@
                     </li>
                 </ul>
                 <select name="network-selector" id="network-selector" class="form-select" style="width: auto;">
-                    <option value="history">History</option>
-                    <option value="state">State</option>
-                    <option value="beacon">Beacon</option>
+                    <option value="History">History</option>
+                    <option value="State">State</option>
+                    <option value="Beacon">Beacon</option>
                 </select>
             </div>
         </div>

--- a/migration/src/lib.rs
+++ b/migration/src/lib.rs
@@ -15,6 +15,7 @@ mod m20240515_064320_state_roots;
 mod m20240720_111606_create_census_index;
 mod m20240814_121507_census_subnetwork;
 mod m20240919_121611_census_subnetwork_index;
+mod m20241010_151313_audit_stats_performance;
 
 pub struct Migrator;
 
@@ -37,6 +38,7 @@ impl MigratorTrait for Migrator {
             Box::new(m20240720_111606_create_census_index::Migration),
             Box::new(m20240814_121507_census_subnetwork::Migration),
             Box::new(m20240919_121611_census_subnetwork_index::Migration),
+            Box::new(m20241010_151313_audit_stats_performance::Migration),
         ]
     }
 }

--- a/migration/src/m20241010_151313_audit_stats_performance.rs
+++ b/migration/src/m20241010_151313_audit_stats_performance.rs
@@ -1,0 +1,59 @@
+use sea_orm_migration::prelude::*;
+
+#[derive(DeriveMigrationName)]
+pub struct Migration;
+
+const INDEX_AUDIT_STATS_PERF: &str = "idx_audit_stats_perf";
+const INDEX_CONTENT_PROTOCOL_ID_IDX: &str = "idx_content_protocol_id";
+
+#[async_trait::async_trait]
+impl MigrationTrait for Migration {
+    async fn up(&self, manager: &SchemaManager) -> Result<(), DbErr> {
+        let _ = manager
+            .create_index(
+                Index::create()
+                    .name(INDEX_AUDIT_STATS_PERF)
+                    .table(ContentAudit::Table)
+                    .col(ContentAudit::Result)
+                    .col(ContentAudit::CreatedAt)
+                    .col(ContentAudit::ContentKey)
+                    .to_owned(),
+            )
+            .await;
+
+        manager
+            .create_index(
+                Index::create()
+                    .name(INDEX_CONTENT_PROTOCOL_ID_IDX)
+                    .table(Content::Table)
+                    .col(Content::ProtocolId)
+                    .col(Content::Id)
+                    .to_owned(),
+            )
+            .await
+    }
+
+    async fn down(&self, manager: &SchemaManager) -> Result<(), DbErr> {
+        let _ = manager
+            .drop_index(Index::drop().name(INDEX_AUDIT_STATS_PERF).to_owned())
+            .await;
+        manager
+            .drop_index(Index::drop().name(INDEX_CONTENT_PROTOCOL_ID_IDX).to_owned())
+            .await
+    }
+}
+
+#[derive(Iden)]
+enum ContentAudit {
+    Table,
+    ContentKey,
+    CreatedAt,
+    Result,
+}
+
+#[derive(Iden)]
+enum Content {
+    Table,
+    ProtocolId,
+    Id,
+}


### PR DESCRIPTION
This PR:

- activates population of state root data for blocks 0 - 1 million via a new `glados_monitor_state` container in `docker-compose.yml`
- activates auditing of state root data via a new `glados_audit_state` container in `docker-compose.yml`
- implements toggling of the audit dashboard between history and state