### PR TITLE
feat(web): visualize transfer failures in audit

### DIFF
--- a/glados-web/assets/css/trace.css
+++ b/glados-web/assets/css/trace.css
@@ -96,6 +96,10 @@
     background: #956955;
 }
 
+#transfer-failure {
+  background: #e15759;
+}
+
 #cancelled {
   background: #edc949;
 }

--- a/glados-web/assets/js/trace/main.js
+++ b/glados-web/assets/js/trace/main.js
@@ -87,6 +87,8 @@ function createGraphData(trace) {
             } else {
                 if ('receivedFrom' in trace && trace.receivedFrom == nodeId) {
                     group = colors.green;
+                } else if (nodeId in trace.failures) {
+                    group = colors.red;
                 } else if (respondedWith.length == 0) {
                     group = colors.brown;
                 } else if (trace.cancelled.includes(nodeId)) {
@@ -118,8 +120,10 @@ function createGraphData(trace) {
             if (!nodesSeen.includes(nodeIdTarget)) {
                 let group = colors.gray;
 
-                if (trace.cancelled.includes(nodeIdTarget)) {
-                  group = colors.yellow
+                if (nodeIdTarget in trace.failures) {
+                    group = colors.red;
+                } else if (trace.cancelled.includes(nodeIdTarget)) {
+                    group = colors.yellow
                 }
 
                 nodes.push({

--- a/glados-web/templates/contentaudit_detail.html
+++ b/glados-web/templates/contentaudit_detail.html
@@ -42,6 +42,8 @@
                 <text>No Progress</text>
                 <div class="legend-dot" id="found-content"></div>
                 <text>Content Found</text>
+                <div class="legend-dot" id="transfer-failure"></div>
+                <text>Transfer Failure</text>
                 <div class="legend-dot" id="cancelled"></div>
                 <text>Request Cancelled</text>
                 <div class="should-store-legend-dot" id="should-store"></div>


### PR DESCRIPTION
Fix #319 

In the audit detail page, show the peer as a red dot when a content transfer fails due to any of:
- utp connection failure/timeout
- utp transfer failure/timeout
- data determined to be invalid

---

I tested this locally with the three failure types on a single audit, and all three peers showed up red:

![image](https://github.com/user-attachments/assets/f3a58473-e321-4e13-ba9f-f28ddb0a004a)

I hacked this temporary trace in:
```diff
diff --git a/glados-web/src/routes.rs b/glados-web/src/routes.rs
index dd8d156..99a0719 100644
--- a/glados-web/src/routes.rs
+++ b/glados-web/src/routes.rs
@@ -546,7 +546,12 @@ pub async fn contentaudit_detail(
         }
     };
 
-    let trace_string = &audit.trace;
+    let trace_string = r#"{"cancelled":[],
+  "failures":{
+   "0x11ee0e3a44e8977c02da63bd85ab1605f41e76ce9cb6b05f0af1a8bb3a072438":{"durationMs":12,"failure":"utpTransferFailed"},
+   "0x500199e73f27cdea5f3ff6db682fe4642a71817c707eea3ba6e2f09dd42fba87":{"durationMs":12,"failure":"invalidContent"},
+   "0xe29f9d86ce3db1a2b75ee9b0730edb1b9d5499648b5cb98277186a7d13be9e93":{"durationMs":12,"failure":"utpConnectionFailed"}},
+  "metadata":{"0x11ee0e3a44e8977c02da63bd85ab1605f41e76ce9cb6b05f0af1a8bb3a072438":{"distance":"0xb0b8179a9b61afc03967744c519f3e96f2bd5406bdd5cb7ec0bb91b7e0a2dd9e","enr":"enr:-IS4QC1ZwVrOR3X1ajG32ZWCNdwmcu96eppBGfjkq2-ihTRDfNAA-tKE_9EDy-zXgxq13NyEGdkUSiEUhVT1Sa1SvB4BgmlkgnY0gmlwhMOP65WJc2VjcDI1NmsxoQPoJDmPi2rZAEtxNzO8i9OGGJMN4wzgZe1d50lRakH_6IN1ZHCCH0A","radius":null},"0x4eddb94975a324cc7b9dd3cd6807f8a54a350f9e7dcfefbf5abaa71057387891":{"distance":"0xef8ba0e9aa2a1c704020c43cbc33d0364c962d565cac949e90f09e1c8d9d8137","enr":"enr:-IS4QBzWQHf9Q0XeVDWKPeCPxoAot9-UwE-gU0tjXRoqu2QXYKiVcCsS7U9hduNOTkIT8gSHPe0STYQpCiWjM7Fo89IBgmlkgnY0gmlwhKzwLgiJc2VjcDI1NmsxoQIWvQ5rjC8gyOy5jxEYVjF_Hs6uzJBXAarQ9vwyWTBKA4N1ZHCCH0A","radius":null},"0x500199e73f27cdea5f3ff6db682fe4642a71817c707eea3ba6e2f09dd42fba87":{"distance":"0xf1578047e0aef5566482e12abc1bccf72cd2a3b4511d911a6ca8c9910e8a4321","enr":"enr:-IS4QG4nDBmZE9_RGbRD-3c8n3o465Ume0ZDGQniBwo-kncVA6D_egfz5zVYxXdWekp9UBmgp8hqYW_b3STCJPsK6VcBgmlkgnY0gmlwhDK9d2-Jc2VjcDI1NmsxoQKCdolM68EWmwMvBc3wbXhof4qZVKLPYRm5jhQsV3aFrYN1ZHCCH0A","radius":null},"0xa15619a0df8938bc3bbd17f1d434289306a322c821637b21ca4a390cdaa5f9a6":{"distance":"0x0000000000000000000000000000000000000000000000000000000000000000","enr":"enr:-IS4QLS5LbkOFHgdC4Cif3dcz5iFz2K7dwOWGXmOy808UuDcEhCNJFVML6ZExx0I834UETxlfwcaL8kLftvZMF9RzRkBgmlkgnY0gmlwhONfSgKJc2VjcDI1NmsxoQNkyXBtxYCzqrosGD-RDVXWExOf-ykeSf585NlGLXVvVoN1ZHCCH0A","radius":null},"0xd60df5790af99920c378ece0d64e14257de7a6782351a350c22750776356b980":{"distance":"0x775becd9d570a19cf8c5fb11027a3cb67b4484b00232d871086d697bb9f34026","enr":"enr:-IS4QK6ZxxHByUdsww0HAmpfupix3sstYcTA4LJHC_e0VJSII1yPaG28MTBdkPX8FVggO2--_OuVHxFu_1Z8sj9wHWoBgmlkgnY0gmlwhE6j8SOJc2VjcDI1NmsxoQJOiNTw9LPv42hEQqJQLM7MgfzsayExbfNKXfvZGx-mgIN1ZHCCH0A","radius":null},"0xe29f9d86ce3db1a2b75ee9b0730edb1b9d5499648b5cb98277186a7d13be9e93":{"distance":"0x43c9842611b4891e8ce3fe41a73af3889bf7bbacaa3fc2a3bd525371c91b6735","enr":"enr:-IS4QD1qLn9iL49yZLBTp-C5y8CrsBZUPdL5KL51rJCgnDiQHRF1d0pCVYimUDiEIZ7aYsDN3lBBNlSowNnLsDeau7sBgmlkgnY0gmlwhNcZPXOJc2VjcDI1NmsxoQMYwoEfUFKzpAHWXXDAgNNGeErOA5kGgx7BFnEqPBJKuIN1ZHCCH0A","radius":null}},"origin":"0xa15619a0df8938bc3bbd17f1d434289306a322c821637b21ca4a390cdaa5f9a6","receivedFrom":"0x4eddb94975a324cc7b9dd3cd6807f8a54a350f9e7dcfefbf5abaa71057387891","responses":{"0x11ee0e3a44e8977c02da63bd85ab1605f41e76ce9cb6b05f0af1a8bb3a072438":{"durationMs":12,"respondedWith":[]},"0x4eddb94975a324cc7b9dd3cd6807f8a54a350f9e7dcfefbf5abaa71057387891":{"durationMs":12,"respondedWith":[]},"0x500199e73f27cdea5f3ff6db682fe4642a71817c707eea3ba6e2f09dd42fba87":{"durationMs":12,"respondedWith":[]},"0xa15619a0df8938bc3bbd17f1d434289306a322c821637b21ca4a390cdaa5f9a6":{"durationMs":9,"respondedWith":["0xe29f9d86ce3db1a2b75ee9b0730edb1b9d5499648b5cb98277186a7d13be9e93","0xd60df5790af99920c378ece0d64e14257de7a6782351a350c22750776356b980","0x11ee0e3a44e8977c02da63bd85ab1605f41e76ce9cb6b05f0af1a8bb3a072438"]},"0xd60df5790af99920c378ece0d64e14257de7a6782351a350c22750776356b980":{"durationMs":12,"respondedWith":["0x500199e73f27cdea5f3ff6db682fe4642a71817c707eea3ba6e2f09dd42fba87","0x4eddb94975a324cc7b9dd3cd6807f8a54a350f9e7dcfefbf5abaa71057387891"]},"0xe29f9d86ce3db1a2b75ee9b0730edb1b9d5499648b5cb98277186a7d13be9e93":{"durationMs":12,"respondedWith":[]}},"startedAtMs":{"nanos_since_epoch":433192105,"secs_since_epoch":1727484262},"targetId":[161,86,25,160,223,137,56,188,59,189,23,241,212,52,40,147,6,163,34,200,33,99,123,33,202,74,57,12,218,165,249,166]}"#;
     let mut trace: Option<QueryTrace> = match serde_json::from_str(trace_string) {
         Ok(trace) => Some(trace),
         Err(err) => {
```