### PR TITLE
chore: new ethportal-api with recursive_find -> get

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -104,17 +104,63 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5c6cb57a04249c6480766f7f7cef5467412af1490f8d1e243141daddada3264f"
 
 [[package]]
-name = "alloy-consensus"
-version = "0.3.6"
+name = "alloy"
+version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "629b62e38d471cc15fea534eb7283d2f8a4e8bdb1811bcc5d66dda6cfce6fae1"
+checksum = "056f2c01b2aed86e15b43c47d109bfc8b82553dc34e66452875e51247ec31ab2"
+dependencies = [
+ "alloy-consensus",
+ "alloy-core",
+ "alloy-eips",
+ "alloy-genesis",
+ "alloy-rpc-types",
+ "alloy-serde",
+]
+
+[[package]]
+name = "alloy-consensus"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "705687d5bfd019fee57cf9e206b27b30a9a9617535d5590a02b171e813208f8e"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
  "alloy-rlp",
  "alloy-serde",
+ "auto_impl",
  "c-kzg",
+ "derive_more 1.0.0",
  "serde",
+]
+
+[[package]]
+name = "alloy-core"
+version = "0.8.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5ce854562e7cafd5049189d0268d6e5cba05fe6c9cb7c6f8126a79b94800629c"
+dependencies = [
+ "alloy-dyn-abi",
+ "alloy-json-abi",
+ "alloy-primitives",
+ "alloy-rlp",
+ "alloy-sol-types",
+]
+
+[[package]]
+name = "alloy-dyn-abi"
+version = "0.8.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b499852e1d0e9b8c6db0f24c48998e647c0d5762a01090f955106a7700e4611"
+dependencies = [
+ "alloy-json-abi",
+ "alloy-primitives",
+ "alloy-sol-type-parser",
+ "alloy-sol-types",
+ "const-hex",
+ "itoa",
+ "serde",
+ "serde_json",
+ "winnow 0.6.20",
 ]
 
 [[package]]
@@ -141,9 +187,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-eips"
-version = "0.3.6"
+version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f923dd5fca5f67a43d81ed3ebad0880bd41f6dd0ada930030353ac356c54cd0f"
+checksum = "6ffb906284a1e1f63c4607da2068c8197458a352d0b3e9796e67353d72a9be85"
 dependencies = [
  "alloy-eip2930",
  "alloy-eip7702",
@@ -158,11 +204,35 @@ dependencies = [
 ]
 
 [[package]]
-name = "alloy-network-primitives"
-version = "0.3.6"
+name = "alloy-genesis"
+version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94ad40869867ed2d9cd3842b1e800889e5b49e6b92da346e93862b4a741bedf3"
+checksum = "8429cf4554eed9b40feec7f4451113e76596086447550275e3def933faf47ce3"
 dependencies = [
+ "alloy-primitives",
+ "alloy-serde",
+ "serde",
+]
+
+[[package]]
+name = "alloy-json-abi"
+version = "0.8.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "03c66eec1acdd96b39b995b8f5ee5239bc0c871d62c527ae1ac9fd1d7fecd455"
+dependencies = [
+ "alloy-primitives",
+ "alloy-sol-type-parser",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
+name = "alloy-network-primitives"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "801492711d4392b2ccf5fc0bc69e299fa1aab15167d74dcaa9aab96a54f684bd"
+dependencies = [
+ "alloy-consensus",
  "alloy-eips",
  "alloy-primitives",
  "alloy-serde",
@@ -222,38 +292,21 @@ dependencies = [
 
 [[package]]
 name = "alloy-rpc-types"
-version = "0.3.6"
+version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "64333d639f2a0cf73491813c629a405744e16343a4bc5640931be707c345ecc5"
+checksum = "9ffc534b7919e18f35e3aa1f507b6f3d9d92ec298463a9f6beaac112809d8d06"
 dependencies = [
- "alloy-rpc-types-engine",
+ "alloy-primitives",
  "alloy-rpc-types-eth",
  "alloy-serde",
  "serde",
 ]
 
 [[package]]
-name = "alloy-rpc-types-engine"
-version = "0.3.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1464c4dd646e1bdfde86ae65ce5ba168dbb29180b478011fe87117ae46b1629b"
-dependencies = [
- "alloy-consensus",
- "alloy-eips",
- "alloy-primitives",
- "alloy-rlp",
- "alloy-serde",
- "derive_more 1.0.0",
- "jsonwebtoken",
- "rand",
- "serde",
-]
-
-[[package]]
 name = "alloy-rpc-types-eth"
-version = "0.3.6"
+version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "83aa984386deda02482660aa31cb8ca1e63d533f1c31a52d7d181ac5ec68e9b8"
+checksum = "413f4aa3ccf2c3e4234a047c5fa4727916d7daf25a89f9b765df0ba09784fd87"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -262,9 +315,7 @@ dependencies = [
  "alloy-rlp",
  "alloy-serde",
  "alloy-sol-types",
- "cfg-if",
  "derive_more 1.0.0",
- "hashbrown 0.14.5",
  "itertools 0.13.0",
  "serde",
  "serde_json",
@@ -272,9 +323,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-serde"
-version = "0.3.6"
+version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "731f75ec5d383107fd745d781619bd9cedf145836c51ecb991623d41278e71fa"
+checksum = "9dff0ab1cdd43ca001e324dc27ee0e8606bd2161d6623c63e0e0b8c4dfc13600"
 dependencies = [
  "alloy-primitives",
  "serde",
@@ -329,14 +380,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "alloy-sol-type-parser"
+version = "0.8.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f631f0bd9a9d79619b27c91b6b1ab2c4ef4e606a65192369a1ee05d40dcf81cc"
+dependencies = [
+ "serde",
+ "winnow 0.6.20",
+]
+
+[[package]]
 name = "alloy-sol-types"
 version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d86a533ce22525969661b25dfe296c112d35eb6861f188fd284f8bd4bb3842ae"
 dependencies = [
+ "alloy-json-abi",
  "alloy-primitives",
  "alloy-sol-macro",
  "const-hex",
+ "serde",
 ]
 
 [[package]]
@@ -1966,12 +2029,11 @@ dependencies = [
 [[package]]
 name = "ethportal-api"
 version = "0.2.2"
-source = "git+https://github.com/ethereum/trin?rev=bf54a8aea934d29dc8fdca60f2d463190a1e9c98#bf54a8aea934d29dc8fdca60f2d463190a1e9c98"
+source = "git+https://github.com/ethereum/trin?rev=3fc51309a59334a1e5498baf4cdc2e868b4efe68#3fc51309a59334a1e5498baf4cdc2e868b4efe68"
 dependencies = [
- "alloy-consensus",
- "alloy-primitives",
+ "alloy",
  "alloy-rlp",
- "alloy-rpc-types",
+ "alloy-rpc-types-eth",
  "anyhow",
  "base64 0.13.1",
  "bimap",
@@ -2347,10 +2409,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c4567c8db10ae91089c99af84c68c38da3ec2f087c3f82960bcdbf3656b6f4d7"
 dependencies = [
  "cfg-if",
- "js-sys",
  "libc",
  "wasi",
- "wasm-bindgen",
 ]
 
 [[package]]
@@ -2626,7 +2686,6 @@ checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
 dependencies = [
  "ahash 0.8.11",
  "allocator-api2",
- "serde",
 ]
 
 [[package]]
@@ -3371,21 +3430,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "jsonwebtoken"
-version = "9.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b9ae10193d25051e74945f1ea2d0b42e03cc3b890f7e4cc5faa44997d808193f"
-dependencies = [
- "base64 0.21.7",
- "js-sys",
- "pem",
- "ring",
- "serde",
- "serde_json",
- "simple_asn1",
-]
-
-[[package]]
 name = "k256"
 version = "0.13.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3946,16 +3990,6 @@ name = "paste"
 version = "1.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
-
-[[package]]
-name = "pem"
-version = "3.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e459365e590736a54c3fa561947c84837534b8e9af6fc5bf781307e82658fae"
-dependencies = [
- "base64 0.22.1",
- "serde",
-]
 
 [[package]]
 name = "percent-encoding"
@@ -5306,18 +5340,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f27f6278552951f1f2b8cf9da965d10969b2efdea95a6ec47987ab46edfe263a"
 
 [[package]]
-name = "simple_asn1"
-version = "0.6.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "adc4e5204eb1910f40f9cfa375f6f05b68c3abac4b6fd879c8ff5e7ae8a0a085"
-dependencies = [
- "num-bigint",
- "num-traits",
- "thiserror",
- "time",
-]
-
-[[package]]
 name = "slab"
 version = "0.4.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5900,7 +5922,7 @@ checksum = "1b5bb770da30e5cbfde35a2d7b9b8a2c4b8ef89548a7a6aeab5c9a576e3e7421"
 dependencies = [
  "indexmap 2.6.0",
  "toml_datetime",
- "winnow",
+ "winnow 0.5.40",
 ]
 
 [[package]]
@@ -5911,7 +5933,7 @@ checksum = "6a8534fd7f78b5405e860340ad6575217ce99f38d4d5c8f2442cb5ecb50090e1"
 dependencies = [
  "indexmap 2.6.0",
  "toml_datetime",
- "winnow",
+ "winnow 0.5.40",
 ]
 
 [[package]]
@@ -6054,7 +6076,7 @@ dependencies = [
 [[package]]
 name = "trin-utils"
 version = "0.1.1-alpha.1"
-source = "git+https://github.com/ethereum/trin?rev=bf54a8aea934d29dc8fdca60f2d463190a1e9c98#bf54a8aea934d29dc8fdca60f2d463190a1e9c98"
+source = "git+https://github.com/ethereum/trin?rev=3fc51309a59334a1e5498baf4cdc2e868b4efe68#3fc51309a59334a1e5498baf4cdc2e868b4efe68"
 dependencies = [
  "ansi_term",
  "atty",
@@ -6682,6 +6704,15 @@ name = "winnow"
 version = "0.5.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f593a95398737aeed53e489c785df13f3618e41dbcd6718c6addbf1395aa6876"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
+name = "winnow"
+version = "0.6.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "36c1fec1a2bb5866f07c25f68c26e565c4c200aebb96d7e55710c19d3e8ac49b"
 dependencies = [
  "memchr",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,7 @@ clap = { version = "4.0.26", features = ["derive"] }
 enr = "0.10.0"
 entity = { path = "entity" }
 env_logger = "0.10.0"
-ethportal-api = { git = "https://github.com/ethereum/trin", rev = "bf54a8aea934d29dc8fdca60f2d463190a1e9c98" }
+ethportal-api = { git = "https://github.com/ethereum/trin", rev = "3fc51309a59334a1e5498baf4cdc2e868b4efe68" }
 glados-core = { path = "glados-core" }
 glados-monitor = { path = "glados-monitor" }
 glados-audit = { path = "glados-audit" }

--- a/glados-audit/src/state.rs
+++ b/glados-audit/src/state.rs
@@ -161,7 +161,7 @@ async fn random_state_walk(
     };
     let mut current_content_key = root_content_key.clone();
     loop {
-        let response = match StateNetworkApiClient::recursive_find_content(
+        let response = match StateNetworkApiClient::get_content(
             &client,
             StateContentKey::AccountTrieNode(current_content_key.clone()),
         )
@@ -170,7 +170,7 @@ async fn random_state_walk(
             Ok(response) => response,
             Err(err) => {
                 return Err((
-                    anyhow!("Error recursive_find_content failed with: {err:?}"),
+                    anyhow!("Error get_content failed with: {err:?}"),
                     current_content_key,
                 ));
             }
@@ -183,9 +183,7 @@ async fn random_state_walk(
             } => content_value,
             other_content_info => {
                 return Err((
-                    anyhow!(
-                        "Error unexpected recursive_find_content response: {other_content_info:?}"
-                    ),
+                    anyhow!("Error unexpected get_content response: {other_content_info:?}"),
                     current_content_key,
                 ));
             }

--- a/glados-core/src/jsonrpc.rs
+++ b/glados-core/src/jsonrpc.rs
@@ -170,27 +170,8 @@ impl PortalApi {
     ) -> Result<Option<Content>, JsonRpcError> {
         let raw_key = RawContentKey::from_iter(&content.content_key);
         match content.protocol_id {
-            content::SubProtocol::History => match HistoryNetworkApiClient::recursive_find_content(
-                &self.client,
-                raw_key.try_into()?,
-            )
-            .await
-            {
-                Ok(ContentInfo::Content { content, .. }) => Ok(Some(Content {
-                    raw: content.into(),
-                })),
-                Ok(_) => Ok(None),
-                Err(err) => match err.into() {
-                    JsonRpcError::ContentNotFound { trace: _ } => Ok(None),
-                    err => Err(err),
-                },
-            },
-            content::SubProtocol::State => {
-                match StateNetworkApiClient::recursive_find_content(
-                    &self.client,
-                    raw_key.try_into()?,
-                )
-                .await
+            content::SubProtocol::History => {
+                match HistoryNetworkApiClient::get_content(&self.client, raw_key.try_into()?).await
                 {
                     Ok(ContentInfo::Content { content, .. }) => Ok(Some(Content {
                         raw: content.into(),
@@ -202,13 +183,20 @@ impl PortalApi {
                     },
                 }
             }
+            content::SubProtocol::State => {
+                match StateNetworkApiClient::get_content(&self.client, raw_key.try_into()?).await {
+                    Ok(ContentInfo::Content { content, .. }) => Ok(Some(Content {
+                        raw: content.into(),
+                    })),
+                    Ok(_) => Ok(None),
+                    Err(err) => match err.into() {
+                        JsonRpcError::ContentNotFound { trace: _ } => Ok(None),
+                        err => Err(err),
+                    },
+                }
+            }
             content::SubProtocol::Beacon => {
-                match BeaconNetworkApiClient::recursive_find_content(
-                    &self.client,
-                    raw_key.try_into()?,
-                )
-                .await
-                {
+                match BeaconNetworkApiClient::get_content(&self.client, raw_key.try_into()?).await {
                     Ok(ContentInfo::Content { content, .. }) => Ok(Some(Content {
                         raw: content.into(),
                     })),
@@ -229,11 +217,8 @@ impl PortalApi {
         let raw_key = RawContentKey::from_iter(&content.content_key);
         match content.protocol_id {
             content::SubProtocol::History => {
-                match HistoryNetworkApiClient::trace_recursive_find_content(
-                    &self.client,
-                    raw_key.try_into()?,
-                )
-                .await
+                match HistoryNetworkApiClient::trace_get_content(&self.client, raw_key.try_into()?)
+                    .await
                 {
                     Ok(TraceContentInfo { content, trace, .. }) => Ok((
                         Some(Content {
@@ -250,11 +235,8 @@ impl PortalApi {
                 }
             }
             content::SubProtocol::State => {
-                match StateNetworkApiClient::trace_recursive_find_content(
-                    &self.client,
-                    raw_key.try_into()?,
-                )
-                .await
+                match StateNetworkApiClient::trace_get_content(&self.client, raw_key.try_into()?)
+                    .await
                 {
                     Ok(TraceContentInfo { content, trace, .. }) => Ok((
                         Some(Content {
@@ -271,11 +253,8 @@ impl PortalApi {
                 }
             }
             content::SubProtocol::Beacon => {
-                match BeaconNetworkApiClient::trace_recursive_find_content(
-                    &self.client,
-                    raw_key.try_into()?,
-                )
-                .await
+                match BeaconNetworkApiClient::trace_get_content(&self.client, raw_key.try_into()?)
+                    .await
                 {
                     Ok(TraceContentInfo { content, trace, .. }) => Ok((
                         Some(Content {


### PR DESCRIPTION
The json-rpc api changed calls with recursive_find_content to get_content (and the same with trace).

Update to get the latest ethportal-api with the changes.