### PR TITLE
chore: update ethportal-api which updates ContentInfo return types

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2029,7 +2029,7 @@ dependencies = [
 [[package]]
 name = "ethportal-api"
 version = "0.2.2"
-source = "git+https://github.com/ethereum/trin?rev=3fc51309a59334a1e5498baf4cdc2e868b4efe68#3fc51309a59334a1e5498baf4cdc2e868b4efe68"
+source = "git+https://github.com/ethereum/trin?rev=4b212d4f3e8afa7b3298eebd4b4b6e3ec04d680f#4b212d4f3e8afa7b3298eebd4b4b6e3ec04d680f"
 dependencies = [
  "alloy",
  "alloy-rlp",
@@ -6076,7 +6076,7 @@ dependencies = [
 [[package]]
 name = "trin-utils"
 version = "0.1.1-alpha.1"
-source = "git+https://github.com/ethereum/trin?rev=3fc51309a59334a1e5498baf4cdc2e868b4efe68#3fc51309a59334a1e5498baf4cdc2e868b4efe68"
+source = "git+https://github.com/ethereum/trin?rev=4b212d4f3e8afa7b3298eebd4b4b6e3ec04d680f#4b212d4f3e8afa7b3298eebd4b4b6e3ec04d680f"
 dependencies = [
  "ansi_term",
  "atty",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,7 @@ clap = { version = "4.0.26", features = ["derive"] }
 enr = "0.10.0"
 entity = { path = "entity" }
 env_logger = "0.10.0"
-ethportal-api = { git = "https://github.com/ethereum/trin", rev = "3fc51309a59334a1e5498baf4cdc2e868b4efe68" }
+ethportal-api = { git = "https://github.com/ethereum/trin", rev = "4b212d4f3e8afa7b3298eebd4b4b6e3ec04d680f" }
 glados-core = { path = "glados-core" }
 glados-monitor = { path = "glados-monitor" }
 glados-audit = { path = "glados-audit" }

--- a/glados-audit/src/state.rs
+++ b/glados-audit/src/state.rs
@@ -177,12 +177,7 @@ async fn random_state_walk(
             }
         };
 
-        let GetContentInfo {
-            content: content_value,
-            ..
-        } = response;
-
-        let encoded_trie_node: EncodedTrieNode = content_value.to_vec().into();
+        let encoded_trie_node: EncodedTrieNode = response.content.to_vec().into();
 
         let trie_node = encoded_trie_node.as_trie_node().map_err(|err| {
             (

--- a/glados-audit/src/state.rs
+++ b/glados-audit/src/state.rs
@@ -13,8 +13,9 @@ use eth_trie::node::Node;
 use ethportal_api::{
     jsonrpsee::http_client::HttpClient,
     types::{
-        content_key::state::AccountTrieNodeKey, portal::ContentInfo, state_trie::nibbles::Nibbles,
-        state_trie::EncodedTrieNode,
+        content_key::state::AccountTrieNodeKey,
+        portal::GetContentInfo,
+        state_trie::{nibbles::Nibbles, EncodedTrieNode},
     },
     StateContentKey, StateNetworkApiClient,
 };
@@ -176,18 +177,10 @@ async fn random_state_walk(
             }
         };
 
-        let content_value = match response {
-            ContentInfo::Content {
-                content: content_value,
-                ..
-            } => content_value,
-            other_content_info => {
-                return Err((
-                    anyhow!("Error unexpected get_content response: {other_content_info:?}"),
-                    current_content_key,
-                ));
-            }
-        };
+        let GetContentInfo {
+            content: content_value,
+            ..
+        } = response;
 
         let encoded_trie_node: EncodedTrieNode = content_value.to_vec().into();
 

--- a/glados-audit/src/state.rs
+++ b/glados-audit/src/state.rs
@@ -14,7 +14,6 @@ use ethportal_api::{
     jsonrpsee::http_client::HttpClient,
     types::{
         content_key::state::AccountTrieNodeKey,
-        portal::GetContentInfo,
         state_trie::{nibbles::Nibbles, EncodedTrieNode},
     },
     StateContentKey, StateNetworkApiClient,

--- a/glados-core/src/jsonrpc.rs
+++ b/glados-core/src/jsonrpc.rs
@@ -173,8 +173,8 @@ impl PortalApi {
             content::SubProtocol::History => {
                 match HistoryNetworkApiClient::get_content(&self.client, raw_key.try_into()?).await
                 {
-                    Ok(GetContentInfo { content, .. }) => Ok(Some(Content {
-                        raw: content.into(),
+                    Ok(content_info) => Ok(Some(Content {
+                        raw: content_info.content.into(),
                     })),
                     Err(err) => match err.into() {
                         JsonRpcError::ContentNotFound { trace: _ } => Ok(None),
@@ -184,8 +184,8 @@ impl PortalApi {
             }
             content::SubProtocol::State => {
                 match StateNetworkApiClient::get_content(&self.client, raw_key.try_into()?).await {
-                    Ok(GetContentInfo { content, .. }) => Ok(Some(Content {
-                        raw: content.into(),
+                    Ok(content_info) => Ok(Some(Content {
+                        raw: content_info.content.into(),
                     })),
                     Err(err) => match err.into() {
                         JsonRpcError::ContentNotFound { trace: _ } => Ok(None),
@@ -195,8 +195,8 @@ impl PortalApi {
             }
             content::SubProtocol::Beacon => {
                 match BeaconNetworkApiClient::get_content(&self.client, raw_key.try_into()?).await {
-                    Ok(GetContentInfo { content, .. }) => Ok(Some(Content {
-                        raw: content.into(),
+                    Ok(content_info) => Ok(Some(Content {
+                        raw: content_info.content.into(),
                     })),
                     Err(err) => match err.into() {
                         JsonRpcError::ContentNotFound { trace: _ } => Ok(None),

--- a/glados-core/src/jsonrpc.rs
+++ b/glados-core/src/jsonrpc.rs
@@ -3,7 +3,7 @@ use std::{path::PathBuf, time::Duration};
 use alloy_primitives::hex::FromHexError;
 use entity::content;
 use ethportal_api::types::enr::Enr;
-use ethportal_api::types::portal::{GetContentInfo, TraceContentInfo};
+use ethportal_api::types::portal::TraceContentInfo;
 use ethportal_api::utils::bytes::ByteUtilsError;
 use ethportal_api::{
     BeaconNetworkApiClient, ContentKeyError, Discv5ApiClient, HistoryNetworkApiClient, NodeInfo,

--- a/glados-core/src/jsonrpc.rs
+++ b/glados-core/src/jsonrpc.rs
@@ -3,7 +3,7 @@ use std::{path::PathBuf, time::Duration};
 use alloy_primitives::hex::FromHexError;
 use entity::content;
 use ethportal_api::types::enr::Enr;
-use ethportal_api::types::portal::{ContentInfo, TraceContentInfo};
+use ethportal_api::types::portal::{GetContentInfo, TraceContentInfo};
 use ethportal_api::utils::bytes::ByteUtilsError;
 use ethportal_api::{
     BeaconNetworkApiClient, ContentKeyError, Discv5ApiClient, HistoryNetworkApiClient, NodeInfo,
@@ -173,10 +173,9 @@ impl PortalApi {
             content::SubProtocol::History => {
                 match HistoryNetworkApiClient::get_content(&self.client, raw_key.try_into()?).await
                 {
-                    Ok(ContentInfo::Content { content, .. }) => Ok(Some(Content {
+                    Ok(GetContentInfo { content, .. }) => Ok(Some(Content {
                         raw: content.into(),
                     })),
-                    Ok(_) => Ok(None),
                     Err(err) => match err.into() {
                         JsonRpcError::ContentNotFound { trace: _ } => Ok(None),
                         err => Err(err),
@@ -185,10 +184,9 @@ impl PortalApi {
             }
             content::SubProtocol::State => {
                 match StateNetworkApiClient::get_content(&self.client, raw_key.try_into()?).await {
-                    Ok(ContentInfo::Content { content, .. }) => Ok(Some(Content {
+                    Ok(GetContentInfo { content, .. }) => Ok(Some(Content {
                         raw: content.into(),
                     })),
-                    Ok(_) => Ok(None),
                     Err(err) => match err.into() {
                         JsonRpcError::ContentNotFound { trace: _ } => Ok(None),
                         err => Err(err),
@@ -197,10 +195,9 @@ impl PortalApi {
             }
             content::SubProtocol::Beacon => {
                 match BeaconNetworkApiClient::get_content(&self.client, raw_key.try_into()?).await {
-                    Ok(ContentInfo::Content { content, .. }) => Ok(Some(Content {
+                    Ok(GetContentInfo { content, .. }) => Ok(Some(Content {
                         raw: content.into(),
                     })),
-                    Ok(_) => Ok(None),
                     Err(err) => match err.into() {
                         JsonRpcError::ContentNotFound { trace: _ } => Ok(None),
                         err => Err(err),


### PR DESCRIPTION
updates the version of ethportal-api this update removes code paths which weren't included in the JSON-RPC return types like content-id which is an internal trin thing.