### PR TITLE
fix: show navbar on mobile

### DIFF
--- a/glados-web/templates/base.html
+++ b/glados-web/templates/base.html
@@ -17,25 +17,28 @@
 <body>
 
     <nav class="navbar navbar-expand-lg navbar-light" style="background-color: #ffffff;">
-        <div class="container-fluid">
-            <div class="collapse navbar-collapse" id="navbarSupportedContent">
-                <ul class="navbar-nav me-auto">
-                    <li class="nav-item">
-                        <a class="nav-link active" style="margin-left: 20px;" href="/">Glados</a>
-                    </li>
-                    <li class="nav-item">
-                        <a class="nav-link active" aria-current="page" style="margin-left: 20px;" href="/audits/">Audit Dashboard</a>
-                    </li>
-                    <li class="nav-item">
-                        <a class="nav-link active" aria-current="page" style="margin-left: 20px;" href="/census/explorer">Census Explorer</a>
-                    </li>
-                </ul>
-                <select name="network-selector" id="network-selector" class="form-select" style="width: auto;">
-                    <option value="History">History</option>
-                    <option value="State">State</option>
-                    <option value="Beacon">Beacon</option>
-                </select>
-            </div>
+    <div class="container-fluid">
+        <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#navbarSupportedContent">
+            <span class="navbar-toggler-icon"></span>
+        </button>
+
+        <div class="collapse navbar-collapse" id="navbarSupportedContent">
+            <ul class="navbar-nav me-auto">
+                <li class="nav-item">
+                    <a class="nav-link active" style="margin-left: 20px;" href="/">Glados</a>
+                </li>
+                <li class="nav-item">
+                    <a class="nav-link active" aria-current="page" style="margin-left: 20px;" href="/audits/">Audit Dashboard</a>
+                </li>
+                <li class="nav-item">
+                    <a class="nav-link active" aria-current="page" style="margin-left: 20px;" href="/census/explorer">Census Explorer</a>
+                </li>
+            </ul>
+            <select name="network-selector" id="network-selector" class="form-select" style="width: auto;">
+                <option value="History">History</option>
+                <option value="State">State</option>
+                <option value="Beacon">Beacon</option>
+            </select>
         </div>
     </nav>
     <hr style="margin-top: 0;">


### PR DESCRIPTION
We were missing a bootstrap `navbar-toggler` element to open the navbar on mobile. 