### PR TITLE
chore: update ethportal-api (content key api changes)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2029,7 +2029,7 @@ dependencies = [
 [[package]]
 name = "ethportal-api"
 version = "0.2.2"
-source = "git+https://github.com/ethereum/trin?rev=4b212d4f3e8afa7b3298eebd4b4b6e3ec04d680f#4b212d4f3e8afa7b3298eebd4b4b6e3ec04d680f"
+source = "git+https://github.com/ethereum/trin?rev=0b5f04364478cd4ea0aadebb41e6681f55640934#0b5f04364478cd4ea0aadebb41e6681f55640934"
 dependencies = [
  "alloy",
  "alloy-rlp",
@@ -6076,7 +6076,7 @@ dependencies = [
 [[package]]
 name = "trin-utils"
 version = "0.1.1-alpha.1"
-source = "git+https://github.com/ethereum/trin?rev=4b212d4f3e8afa7b3298eebd4b4b6e3ec04d680f#4b212d4f3e8afa7b3298eebd4b4b6e3ec04d680f"
+source = "git+https://github.com/ethereum/trin?rev=0b5f04364478cd4ea0aadebb41e6681f55640934#0b5f04364478cd4ea0aadebb41e6681f55640934"
 dependencies = [
  "ansi_term",
  "atty",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,7 @@ clap = { version = "4.0.26", features = ["derive"] }
 enr = "0.10.0"
 entity = { path = "entity" }
 env_logger = "0.10.0"
-ethportal-api = { git = "https://github.com/ethereum/trin", rev = "4b212d4f3e8afa7b3298eebd4b4b6e3ec04d680f" }
+ethportal-api = { git = "https://github.com/ethereum/trin", rev = "0b5f04364478cd4ea0aadebb41e6681f55640934" }
 glados-core = { path = "glados-core" }
 glados-monitor = { path = "glados-monitor" }
 glados-audit = { path = "glados-audit" }

--- a/glados-audit/src/lib.rs
+++ b/glados-audit/src/lib.rs
@@ -163,7 +163,7 @@ pub async fn run_glados_command(conn: DatabaseConnection, command: cli::Command)
         } => (content_key, portal_client),
     };
     let content_key =
-        HistoryContentKey::from_hex(&content_key).expect("needs valid hex-encoded history key");
+        HistoryContentKey::try_from_hex(&content_key).expect("needs valid hex-encoded history key");
 
     let task = AuditTask {
         strategy: SelectionStrategy::History(HistorySelectionStrategy::SpecificContentKey),

--- a/glados-audit/src/validation.rs
+++ b/glados-audit/src/validation.rs
@@ -1,16 +1,15 @@
 use entity::content;
 use ethportal_api::utils::bytes::hex_encode;
-use ethportal_api::{BeaconContentKey, HistoryContentKey, OverlayContentKey, RawContentKey};
+use ethportal_api::{BeaconContentKey, HistoryContentKey, OverlayContentKey};
 use ethportal_api::{BeaconContentValue, ContentValue, HistoryContentValue};
 use tracing::warn;
 
 /// Checks that content bytes correspond to a correctly formatted
 /// content value.
 pub fn content_is_valid(content: &content::Model, content_bytes: &[u8]) -> bool {
-    let raw_key = RawContentKey::from_iter(&content.content_key);
     match content.protocol_id {
         content::SubProtocol::History => {
-            let content_key = match HistoryContentKey::try_from(raw_key) {
+            let content_key = match HistoryContentKey::try_from_bytes(&content.content_key) {
                 Ok(key) => key,
                 Err(err) => {
                     warn!(err=?err, content.content_key=?content.content_key, "Failed to decode history content key.");
@@ -24,7 +23,7 @@ pub fn content_is_valid(content: &content::Model, content_bytes: &[u8]) -> bool 
             true
         }
         content::SubProtocol::Beacon => {
-            let content_key = match BeaconContentKey::try_from(raw_key) {
+            let content_key = match BeaconContentKey::try_from_bytes(&content.content_key) {
                 Ok(key) => key,
                 Err(err) => {
                     warn!(err=?err, content.content_key=?content.content_key, "Failed to decode beacon content key.");

--- a/glados-core/src/jsonrpc.rs
+++ b/glados-core/src/jsonrpc.rs
@@ -6,8 +6,9 @@ use ethportal_api::types::enr::Enr;
 use ethportal_api::types::portal::TraceContentInfo;
 use ethportal_api::utils::bytes::ByteUtilsError;
 use ethportal_api::{
-    BeaconNetworkApiClient, ContentKeyError, Discv5ApiClient, HistoryNetworkApiClient, NodeInfo,
-    RawContentKey, RoutingTableInfo, StateNetworkApiClient, Web3ApiClient,
+    BeaconContentKey, BeaconNetworkApiClient, ContentKeyError, Discv5ApiClient, HistoryContentKey,
+    HistoryNetworkApiClient, NodeInfo, OverlayContentKey, RoutingTableInfo, StateContentKey,
+    StateNetworkApiClient, Web3ApiClient,
 };
 use jsonrpsee::http_client::{HttpClient, HttpClientBuilder};
 use serde_json::json;
@@ -168,10 +169,13 @@ impl PortalApi {
         self,
         content: &content::Model,
     ) -> Result<Option<Content>, JsonRpcError> {
-        let raw_key = RawContentKey::from_iter(&content.content_key);
         match content.protocol_id {
             content::SubProtocol::History => {
-                match HistoryNetworkApiClient::get_content(&self.client, raw_key.try_into()?).await
+                match HistoryNetworkApiClient::get_content(
+                    &self.client,
+                    HistoryContentKey::try_from_bytes(&content.content_key)?,
+                )
+                .await
                 {
                     Ok(content_info) => Ok(Some(Content {
                         raw: content_info.content.into(),
@@ -183,7 +187,12 @@ impl PortalApi {
                 }
             }
             content::SubProtocol::State => {
-                match StateNetworkApiClient::get_content(&self.client, raw_key.try_into()?).await {
+                match StateNetworkApiClient::get_content(
+                    &self.client,
+                    StateContentKey::try_from_bytes(&content.content_key)?,
+                )
+                .await
+                {
                     Ok(content_info) => Ok(Some(Content {
                         raw: content_info.content.into(),
                     })),
@@ -194,7 +203,12 @@ impl PortalApi {
                 }
             }
             content::SubProtocol::Beacon => {
-                match BeaconNetworkApiClient::get_content(&self.client, raw_key.try_into()?).await {
+                match BeaconNetworkApiClient::get_content(
+                    &self.client,
+                    BeaconContentKey::try_from_bytes(&content.content_key)?,
+                )
+                .await
+                {
                     Ok(content_info) => Ok(Some(Content {
                         raw: content_info.content.into(),
                     })),
@@ -211,11 +225,13 @@ impl PortalApi {
         self,
         content: &content::Model,
     ) -> Result<(Option<Content>, String), JsonRpcError> {
-        let raw_key = RawContentKey::from_iter(&content.content_key);
         match content.protocol_id {
             content::SubProtocol::History => {
-                match HistoryNetworkApiClient::trace_get_content(&self.client, raw_key.try_into()?)
-                    .await
+                match HistoryNetworkApiClient::trace_get_content(
+                    &self.client,
+                    HistoryContentKey::try_from_bytes(&content.content_key)?,
+                )
+                .await
                 {
                     Ok(TraceContentInfo { content, trace, .. }) => Ok((
                         Some(Content {
@@ -232,8 +248,11 @@ impl PortalApi {
                 }
             }
             content::SubProtocol::State => {
-                match StateNetworkApiClient::trace_get_content(&self.client, raw_key.try_into()?)
-                    .await
+                match StateNetworkApiClient::trace_get_content(
+                    &self.client,
+                    StateContentKey::try_from_bytes(&content.content_key)?,
+                )
+                .await
                 {
                     Ok(TraceContentInfo { content, trace, .. }) => Ok((
                         Some(Content {
@@ -250,8 +269,11 @@ impl PortalApi {
                 }
             }
             content::SubProtocol::Beacon => {
-                match BeaconNetworkApiClient::trace_get_content(&self.client, raw_key.try_into()?)
-                    .await
+                match BeaconNetworkApiClient::trace_get_content(
+                    &self.client,
+                    BeaconContentKey::try_from_bytes(&content.content_key)?,
+                )
+                .await
                 {
                     Ok(TraceContentInfo { content, trace, .. }) => Ok((
                         Some(Content {

--- a/glados-web/src/routes.rs
+++ b/glados-web/src/routes.rs
@@ -488,15 +488,15 @@ pub async fn contentkey_detail(
         })?;
 
     let (content_id, content_kind) =
-        if let Ok(content_key) = HistoryContentKey::from_hex(&content_key_hex) {
+        if let Ok(content_key) = HistoryContentKey::try_from_hex(&content_key_hex) {
             let content_id = hex_encode(content_key.content_id());
             let content_kind = content_key.to_string();
             (content_id, content_kind)
-        } else if let Ok(content_key) = StateContentKey::from_hex(&content_key_hex) {
+        } else if let Ok(content_key) = StateContentKey::try_from_hex(&content_key_hex) {
             let content_id = hex_encode(content_key.content_id());
             let content_kind = content_key.to_string();
             (content_id, content_kind)
-        } else if let Ok(content_key) = BeaconContentKey::from_hex(&content_key_hex) {
+        } else if let Ok(content_key) = BeaconContentKey::try_from_hex(&content_key_hex) {
             let content_id = hex_encode(content_key.content_id());
             let content_kind = content_key.to_string();
             (content_id, content_kind)


### PR DESCRIPTION
The https://github.com/ethereum/trin/pull/1544 slightly changed content key api.

This PR updates `ethportal-api` dependency and usage.