### PR TITLE
feat: Compute and Display State and Beacon stats

### DIFF
--- a/entity/src/audit_stats.rs
+++ b/entity/src/audit_stats.rs
@@ -1,6 +1,8 @@
 use anyhow::Result;
 use chrono::{DateTime, TimeDelta, Utc};
-use sea_orm::{entity::prelude::*, ActiveValue::NotSet, QueryOrder, Set};
+use sea_orm::{
+    entity::prelude::*, ActiveValue::NotSet, FromQueryResult, QueryOrder, QuerySelect, Set,
+};
 use serde::Serialize;
 
 #[derive(Clone, Debug, DeriveEntityModel, Serialize)]
@@ -27,6 +29,11 @@ pub struct Model {
     pub success_rate_four_fours_headers: f32,
     pub success_rate_four_fours_bodies: f32,
     pub success_rate_four_fours_receipts: f32,
+    pub success_rate_state_all: f32,
+    pub success_rate_state_latest: f32,
+    pub success_rate_state_state_roots: f32,
+    pub success_rate_beacon_all: f32,
+    pub success_rate_beacon_latest: f32,
 }
 
 #[derive(Copy, Clone, Debug, EnumIter, DeriveRelation)]
@@ -55,6 +62,11 @@ pub async fn create(
     success_rate_four_fours_headers: f32,
     success_rate_four_fours_bodies: f32,
     success_rate_four_fours_receipts: f32,
+    success_rate_state_all: f32,
+    success_rate_state_latest: f32,
+    success_rate_state_state_roots: f32,
+    success_rate_beacon_all: f32,
+    success_rate_beacon_latest: f32,
     conn: &DatabaseConnection,
 ) -> Result<Model> {
     let audit_stats = ActiveModel {
@@ -78,15 +90,57 @@ pub async fn create(
         success_rate_four_fours_headers: Set(success_rate_four_fours_headers),
         success_rate_four_fours_bodies: Set(success_rate_four_fours_bodies),
         success_rate_four_fours_receipts: Set(success_rate_four_fours_receipts),
+        success_rate_state_all: Set(success_rate_state_all),
+        success_rate_state_latest: Set(success_rate_state_latest),
+        success_rate_state_state_roots: Set(success_rate_state_state_roots),
+        success_rate_beacon_all: Set(success_rate_beacon_all),
+        success_rate_beacon_latest: Set(success_rate_beacon_latest),
     };
     Ok(audit_stats.insert(conn).await?)
 }
 
-/// Get the most recent audit stat series of the last 7 days.
-pub async fn get_recent_stats(
-    conn: &DatabaseConnection,
-    weeks_ago: i32,
-) -> Result<Vec<Model>, DbErr> {
+#[derive(Clone, Debug, Serialize, FromQueryResult)]
+pub struct HistoryStats {
+    id: i32,
+    timestamp: DateTime<Utc>,
+    num_audits: i32,
+    success_rate_all: f32,
+    success_rate_latest: f32,
+    success_rate_random: f32,
+    success_rate_oldest: f32,
+    success_rate_four_fours: f32,
+    success_rate_all_headers: f32,
+    success_rate_all_bodies: f32,
+    success_rate_all_receipts: f32,
+    success_rate_latest_headers: f32,
+    success_rate_latest_bodies: f32,
+    success_rate_latest_receipts: f32,
+    success_rate_random_headers: f32,
+    success_rate_random_bodies: f32,
+    success_rate_random_receipts: f32,
+    success_rate_four_fours_headers: f32,
+    success_rate_four_fours_bodies: f32,
+    success_rate_four_fours_receipts: f32,
+}
+
+#[derive(Clone, Debug, Serialize, FromQueryResult)]
+pub struct StateStats {
+    id: i32,
+    timestamp: DateTime<Utc>,
+    success_rate_state_all: f32,
+    success_rate_state_latest: f32,
+    success_rate_state_state_roots: f32,
+}
+
+#[derive(Clone, Debug, Serialize, FromQueryResult)]
+pub struct BeaconStats {
+    id: i32,
+    timestamp: DateTime<Utc>,
+    success_rate_beacon_all: f32,
+    success_rate_beacon_latest: f32,
+}
+
+fn compute_week_period(weeks_ago: i32) -> (DateTime<Utc>, DateTime<Utc>) {
     let beginning_days_ago =
         TimeDelta::try_days(7 * (weeks_ago + 1) as i64).expect("Couldn't calculate days ago.");
     let seven_days = TimeDelta::try_days(7).expect("Couldn't calculate 7 day delta.");
@@ -94,10 +148,89 @@ pub async fn get_recent_stats(
     let beginning = Utc::now() - beginning_days_ago;
     let end = beginning + seven_days;
 
+    (beginning, end)
+}
+
+// Get 7 days of history audit stat series.
+pub async fn get_weekly_history_stats(
+    conn: &DatabaseConnection,
+    weeks_ago: i32,
+) -> Result<Vec<HistoryStats>, DbErr> {
+    let (beginning, end) = compute_week_period(weeks_ago);
+
     Entity::find()
+        .select_only()
+        .columns([
+            Column::Id,
+            Column::Timestamp,
+            Column::NumAudits,
+            Column::SuccessRateAll,
+            Column::SuccessRateLatest,
+            Column::SuccessRateRandom,
+            Column::SuccessRateOldest,
+            Column::SuccessRateFourFours,
+            Column::SuccessRateAllHeaders,
+            Column::SuccessRateAllBodies,
+            Column::SuccessRateAllReceipts,
+            Column::SuccessRateLatestHeaders,
+            Column::SuccessRateLatestBodies,
+            Column::SuccessRateLatestReceipts,
+            Column::SuccessRateRandomHeaders,
+            Column::SuccessRateRandomBodies,
+            Column::SuccessRateRandomReceipts,
+            Column::SuccessRateFourFoursHeaders,
+            Column::SuccessRateFourFoursBodies,
+            Column::SuccessRateFourFoursReceipts,
+        ])
         .filter(Column::Timestamp.gt(beginning))
         .filter(Column::Timestamp.lt(end))
         .order_by_asc(Column::Timestamp)
+        .into_model::<HistoryStats>()
+        .all(conn)
+        .await
+}
+/// Get 7 days of state audit stat series.
+pub async fn get_weekly_state_stats(
+    conn: &DatabaseConnection,
+    weeks_ago: i32,
+) -> Result<Vec<StateStats>, DbErr> {
+    let (beginning, end) = compute_week_period(weeks_ago);
+
+    Entity::find()
+        .select_only()
+        .columns([
+            Column::Id,
+            Column::Timestamp,
+            Column::SuccessRateStateAll,
+            Column::SuccessRateStateLatest,
+            Column::SuccessRateStateStateRoots,
+        ])
+        .filter(Column::Timestamp.gt(beginning))
+        .filter(Column::Timestamp.lt(end))
+        .order_by_asc(Column::Timestamp)
+        .into_model::<StateStats>()
+        .all(conn)
+        .await
+}
+/// Get 7 days of beacon audit stat series.
+pub async fn get_weekly_beacon_stats(
+    conn: &DatabaseConnection,
+    weeks_ago: i32,
+) -> Result<Vec<BeaconStats>, DbErr> {
+    let (beginning, end) = compute_week_period(weeks_ago);
+
+    Entity::find()
+        .select_only()
+        .columns([
+            Column::Id,
+            Column::Timestamp,
+            Column::SuccessRateBeaconAll,
+            Column::SuccessRateBeaconLatest,
+        ])
+        .filter(Column::Timestamp.gt(beginning))
+        .filter(Column::Timestamp.lt(end))
+        .order_by_asc(Column::Timestamp)
+        .into_model::<BeaconStats>()
         .all(conn)
         .await
 }

--- a/entity/src/content_audit.rs
+++ b/entity/src/content_audit.rs
@@ -118,6 +118,7 @@ impl From<i32> for StateSelectionStrategy {
     fn from(value: i32) -> Self {
         match value {
             0 => StateSelectionStrategy::StateRoots,
+            1 => StateSelectionStrategy::Latest,
             _ => panic!("Invalid value for StateSelectionStrategy"),
         }
     }
@@ -128,6 +129,7 @@ impl TryFrom<String> for StateSelectionStrategy {
     fn try_from(value: String) -> Result<Self, Self::Error> {
         match value.as_str() {
             "StateRoots" => Ok(StateSelectionStrategy::StateRoots),
+            "Latest" => Ok(StateSelectionStrategy::Latest),
             _ => bail!("Invalid value for StateSelectionStrategy {}", value),
         }
     }

--- a/glados-audit/src/stats.rs
+++ b/glados-audit/src/stats.rs
@@ -42,6 +42,11 @@ async fn record_current_stats(conn: &DatabaseConnection) -> Result<(), DbErr> {
         fourfours_headers,
         fourfours_bodies,
         fourfours_receipts,
+        state_all,
+        state_latest,
+        state_state_roots,
+        beacon_all,
+        beacon_latest,
     ) = tokio::join!(
         get_audit_stats(
             filter_audits(AuditFilters {
@@ -202,7 +207,57 @@ async fn record_current_stats(conn: &DatabaseConnection) -> Result<(), DbErr> {
             },),
             Period::Hour,
             conn
-        )
+        ),
+        get_audit_stats(
+            filter_audits(AuditFilters {
+                strategy: StrategyFilter::All,
+                content_type: ContentTypeFilter::All,
+                success: SuccessFilter::All,
+                network: SubProtocol::State
+            },),
+            Period::Hour,
+            conn
+        ),
+        get_audit_stats(
+            filter_audits(AuditFilters {
+                strategy: StrategyFilter::Latest,
+                content_type: ContentTypeFilter::All,
+                success: SuccessFilter::All,
+                network: SubProtocol::State
+            },),
+            Period::Hour,
+            conn
+        ),
+        get_audit_stats(
+            filter_audits(AuditFilters {
+                strategy: StrategyFilter::StateRoots,
+                content_type: ContentTypeFilter::All,
+                success: SuccessFilter::All,
+                network: SubProtocol::State
+            },),
+            Period::Hour,
+            conn
+        ),
+        get_audit_stats(
+            filter_audits(AuditFilters {
+                strategy: StrategyFilter::All,
+                content_type: ContentTypeFilter::All,
+                success: SuccessFilter::All,
+                network: SubProtocol::Beacon
+            },),
+            Period::Hour,
+            conn
+        ),
+        get_audit_stats(
+            filter_audits(AuditFilters {
+                strategy: StrategyFilter::Latest,
+                content_type: ContentTypeFilter::All,
+                success: SuccessFilter::All,
+                network: SubProtocol::Beacon
+            },),
+            Period::Hour,
+            conn
+        ),
     );
 
     // Handle errors and get success rates.
@@ -223,6 +278,11 @@ async fn record_current_stats(conn: &DatabaseConnection) -> Result<(), DbErr> {
     let success_rate_fourfours_headers = fourfours_headers?.pass_percent;
     let success_rate_fourfours_bodies = fourfours_bodies?.pass_percent;
     let success_rate_fourfours_receipts = fourfours_receipts?.pass_percent;
+    let success_rate_state_all = state_all?.pass_percent;
+    let success_rate_state_latest = state_latest?.pass_percent;
+    let success_rate_state_state_roots = state_state_roots?.pass_percent;
+    let success_rate_beacon_all = beacon_all?.pass_percent;
+    let success_rate_beacon_latest = beacon_latest?.pass_percent;
 
     // Record the values.
     match audit_stats::create(
@@ -245,6 +305,11 @@ async fn record_current_stats(conn: &DatabaseConnection) -> Result<(), DbErr> {
         success_rate_fourfours_headers,
         success_rate_fourfours_bodies,
         success_rate_fourfours_receipts,
+        success_rate_state_all,
+        success_rate_state_latest,
+        success_rate_state_state_roots,
+        success_rate_beacon_all,
+        success_rate_beacon_latest,
         conn,
     )
     .await

--- a/glados-web/assets/js/stats_history.js
+++ b/glados-web/assets/js/stats_history.js
@@ -1,293 +1,396 @@
-let weeksAgo = 0;
+function createMultiLineChart(
+  height,
+  width,
+  dataSets,
+  labels,
+  selectedIndexes,
+  weeksAgo,
+) {
+  // Declare the chart dimensions and margins.
+  const marginTop = 40;
+  const marginRight = 50;
+  const marginBottom = 20;
+  const marginLeft = 40;
 
-function createMultiLineChart(height, width, dataSets) {
-    // Declare the chart dimensions and margins.
-    const marginTop = 40;
-    const marginRight = 50;
-    const marginBottom = 20;
-    const marginLeft = 40;
-
-    // Parse dates if they're not already Date objects
-    dataSets.forEach(dataset => {
-        dataset.forEach(d => {
-            if (!(d.date instanceof Date)) d.date = new Date(d.date);
-        });
+  // Parse dates if they're not already Date objects
+  dataSets.forEach((dataset) => {
+    dataset.forEach((d) => {
+      if (!(d.date instanceof Date)) d.date = new Date(d.date);
     });
+  });
 
-    // Declare the x (horizontal position) scale.
-    const x = d3.scaleTime()
-        .domain(d3.extent(dataSets.flat(), d => d.date))
-        .range([marginLeft, width - marginRight]);
+  // Declare the x (horizontal position) scale.
+  const x = d3
+    .scaleTime()
+    .domain(d3.extent(dataSets.flat(), (d) => d.date))
+    .range([marginLeft, width - marginRight]);
 
-    // Declare the y (vertical position) scale.
-    const y = d3.scaleLinear()
-        .domain([0, d3.max(dataSets.flat(), d => d.value)])
-        .range([height - marginBottom, marginTop]);
+  // Declare the y (vertical position) scale.
+  const y = d3
+    .scaleLinear()
+    .domain([0, d3.max(dataSets.flat(), (d) => d.value)])
+    .range([height - marginBottom, marginTop]);
 
-    // Color palette for the lines.
-    const colors = d3.schemeTableau10;
+  // Color palette for the lines.
+  const colors = d3.schemeTableau10;
 
-    // Array to keep track of which datasets are visible.
-    let visibility = new Array(dataSets.length).fill(true);
+  // Array to keep track of which datasets are visible.
+  let visibility = new Array(dataSets.length).fill(true);
 
-    // Create the SVG container.
-    const svg = d3.create("svg")
-        .attr("width", width)
-        .attr("height", height)
-        .attr("viewBox", [0, 0, width, height])
-        .attr("overflow", "visible")
-        .attr("style", "max-width: 100%; height: auto; height: intrinsic;");
+  // Create the SVG container.
+  const svg = d3
+    .create("svg")
+    .attr("width", width)
+    .attr("height", height)
+    .attr("viewBox", [0, 0, width, height])
+    .attr("overflow", "visible")
+    .attr("style", "max-width: 100%; height: auto; height: intrinsic;");
 
-    // Add the x-axis.
-    svg.append("g")
-        .attr("transform", `translate(0,${height - marginBottom})`)
-        .call(d3.axisBottom(x).ticks(width / 80).tickSizeOuter(0));
-
-    // Add the y-axis, remove the domain line, add grid lines and a label.
-    svg.append("g")
-        .attr("transform", `translate(${marginLeft},0)`)
-        .call(d3.axisLeft(y).ticks(height / 40).tickFormat(d => d + "%"))
-        .call(g => g.select(".domain").remove())
-        .call(g => g.selectAll(".tick line").clone()
-            .attr("x2", width - marginLeft - marginRight)
-            .attr("stroke-opacity", 0.1))
-        .call(g => g.append("text")
-            .attr("x", -marginLeft)
-            .attr("y", 10)
-            .attr("fill", "currentColor")
-            .attr("text-anchor", "start")
-            .text("↑ Success Rate"));
-
-    // Add title
-    svg.append("text")
-        .attr("class", "graph-title")
-        .attr("text-anchor", "middle")
-        .attr("x", width / 2)
-        .attr("y", marginTop / 2)
-        .text("Audit Success, by week");
-
-    // Add lines to the graph.
-    const lines = dataSets.map((dataSet, i) => {
-        const line = d3.line()
-            .defined(d => !isNaN(d.value))
-            .x(d => x(d.date))
-            .y(d => y(d.value));
-
-        return svg.append("path")
-            .datum(dataSet)
-            .attr("fill", "none")
-            .attr("stroke", colors[i % colors.length])
-            .attr("stroke-width", 1.5)
-            .attr("d", line)
-            .attr("class", `line line-${i}`);
-    });
-
-    // Add a legend.
-    const legend = svg.selectAll(".legend")
-        .data(dataSets)
-        .enter().append("g")
-        .attr("class", "legend")
-        .attr("transform", (d, i) => `translate(${width - marginRight + 100}, ${(i * 20) + 30})`) // Position adjusted to the right
-        .style("font", "10px sans-serif")
-        .style("cursor", "pointer")
-        .on("click", function (event, d) {
-            const index = dataSets.indexOf(d);
-            visibility[index] = !visibility[index];
-            d3.select(lines[index].node()).style("opacity", visibility[index] ? 1 : 0);
-            d3.select(this).style("opacity", visibility[index] ? 1 : 0.5); // Adjust the legend item's opacity
-        });
-
-    // Function to dispatch a click event
-    function dispatchClick(element) {
-        const clickEvent = new MouseEvent('click', {
-            'view': window,
-            'bubbles': true,
-            'cancelable': true
-        });
-        element.dispatchEvent(clickEvent);
-    }
-
-    // Select all '.legend' group elements and click on all but the first three
-    let selectedIndexes = [3]
-    svg.selectAll(".legend")
-        .each(function (d, i) {
-            if (!selectedIndexes.includes(i)) {
-                dispatchClick(this);
-            }
-        });
-
-    // Add colored rectangles to the legend.
-    legend.append("rect")
-        .attr("x", -18)
-        .attr("width", 18)
-        .attr("height", 18)
-        .attr("fill", (d, i) => colors[i % colors.length]);
-
-    // Add text to the legend.
-    const labels = ["All", "Latest", "Random", "4444s",
-        "All Headers", "All Bodies", "All Receipts",
-        "Latest Headers", "Latest Bodies", "Latest Receipts",
-        "Random Headers", "Random Bodies", "Random Receipts",
-        "4444s Headers", "4444s Bodies", "4444s Receipts"];
-    legend.append("text")
-        .attr("x", -24)
-        .attr("y", 9)
-        .attr("dy", ".35em")
-        .attr("text-anchor", "end")
-        .text((d, i) => labels[i])
-        .attr("class", "legend-text");
-
-    // Append a vertical line to the chart, initially hidden
-    const verticalLine = svg.append('line')
-        .style('stroke', 'grey')
-        .style('stroke-width', '1px')
-        .style('stroke-dasharray', '3,3')
-        .style('display', 'none'); // Initially hidden
-
-    // Create an overlay for the mouseover event
-    svg.append("rect")
-        .attr("class", "overlay")
-        .attr("x", marginLeft)
-        .attr("y", marginTop)
-        .attr("width", width - marginLeft - marginRight)
-        .attr("height", height - marginTop - marginBottom)
-        .style("fill", "none")
-        .style("pointer-events", "all")
-        .on("mouseover", () => tooltip.style("display", null))
-        .on("mouseout", () => {
-            verticalLine.style('display', 'none');
-            tooltip.style("display", "none");
-        })
-        .on("mousemove", mousemove);
-
-    // Function to handle mouse movements
-    function mousemove(event) {
-        const x0 = x.invert(d3.pointer(event)[0]),
-            formatDate = d3.timeFormat("%H:%M:%S");
-        const xPos = d3.pointer(event)[0];
-        tooltip
-            .attr("transform", `translate(${d3.pointer(event)[0]},0)`)
-            .call(g => g.select("text").text(`${formatDate(x0)}`));
-
-        // Update the vertical line position
-        verticalLine
-            .attr('x1', xPos)
-            .attr('x2', xPos)
-            .attr('y1', marginTop)
-            .attr('y2', height - marginBottom)
-            .style('display', null);
-    }
-
-    // Create a tooltip for displaying the time
-    const tooltip = svg.append("g")
-        .style("display", "none");
-
-    tooltip.append("text")
-        .attr("class", "tooltip-date")
-        .attr("y", marginTop - 4)
-        .attr("x", marginLeft)
-        .attr("text-anchor", "middle")
-        .attr("font-size", "12px")
-        .style("background", "white");
-
-    // Add buttons to the bottom of the legend
-    const buttons = svg.append("g")
-        .attr("transform", `translate(${width - marginRight + 20}, ${dataSets.length * 20 + 30})`);
-
-    // Add the previous button ("<")
-    buttons.append("text")
-        .attr("class", "previous-button")
-        .attr("x", 0)
-        .attr("y", 30)
-        .attr("font-size", "12px")
-        .attr("text-anchor", "start")
-        .text("< Previous")
-        .style("cursor", "pointer")
-        .on("click", () => {
-            weeksAgo++;
-            updateChart(weeksAgo);
-        });
-
-    if (weeksAgo !== 0) {
-        // Add the next button (">")
-        buttons.append("text")
-            .attr("class", "next-button")
-            .attr("x", 15)
-            .attr("y", 50)
-            .attr("font-size", "12px")
-            .attr("text-anchor", "start")
-            .text("Next >")
-            .style("cursor", "pointer")
-            .on("click", () => {
-                if (weeksAgo > 0) {
-                    weeksAgo--;
-                    updateChart(weeksAgo);
-                }
-            });
-    }
-
-    return svg.node();
-}
-
-function convertDataForChart(data) {
-    const successRateKeys = [
-        'success_rate_all',
-        'success_rate_latest',
-        'success_rate_random',
-        'success_rate_four_fours',
-        'success_rate_all_headers',
-        'success_rate_all_bodies',
-        'success_rate_all_receipts',
-        'success_rate_latest_headers',
-        'success_rate_latest_bodies',
-        'success_rate_latest_receipts',
-        'success_rate_random_headers',
-        'success_rate_random_bodies',
-        'success_rate_random_receipts',
-        'success_rate_four_fours_headers',
-        'success_rate_four_fours_bodies',
-        'success_rate_four_fours_receipts'
-    ];
-
-    return successRateKeys.map(key =>
-        data.map(d => ({
-            date: new Date(d.timestamp),
-            value: d[key]
-        }))
+  // Add the x-axis.
+  svg
+    .append("g")
+    .attr("transform", `translate(0,${height - marginBottom})`)
+    .call(
+      d3
+        .axisBottom(x)
+        .ticks(width / 80)
+        .tickSizeOuter(0),
     );
+
+  // Add the y-axis, remove the domain line, add grid lines and a label.
+  svg
+    .append("g")
+    .attr("transform", `translate(${marginLeft},0)`)
+    .call(
+      d3
+        .axisLeft(y)
+        .ticks(height / 40)
+        .tickFormat((d) => d + "%"),
+    )
+    .call((g) => g.select(".domain").remove())
+    .call((g) =>
+      g
+        .selectAll(".tick line")
+        .clone()
+        .attr("x2", width - marginLeft - marginRight)
+        .attr("stroke-opacity", 0.1),
+    )
+    .call((g) =>
+      g
+        .append("text")
+        .attr("x", -marginLeft)
+        .attr("y", 10)
+        .attr("fill", "currentColor")
+        .attr("text-anchor", "start")
+        .text("↑ Success Rate"),
+    );
+
+  // Add title
+  svg
+    .append("text")
+    .attr("class", "graph-title")
+    .attr("text-anchor", "middle")
+    .attr("x", width / 2)
+    .attr("y", marginTop / 2)
+    .text("Audit Success, by week");
+
+  // Add lines to the graph.
+  const lines = dataSets.map((dataSet, i) => {
+    const line = d3
+      .line()
+      .defined((d) => !isNaN(d.value))
+      .x((d) => x(d.date))
+      .y((d) => y(d.value));
+
+    return svg
+      .append("path")
+      .datum(dataSet)
+      .attr("fill", "none")
+      .attr("stroke", colors[i % colors.length])
+      .attr("stroke-width", 1.5)
+      .attr("d", line)
+      .attr("class", `line line-${i}`);
+  });
+
+  // Add a legend.
+  const legend = svg
+    .selectAll(".legend")
+    .data(dataSets)
+    .enter()
+    .append("g")
+    .attr("class", "legend")
+    .attr(
+      "transform",
+      (d, i) => `translate(${width - marginRight + 100}, ${i * 20 + 30})`,
+    ) // Position adjusted to the right
+    .style("font", "10px sans-serif")
+    .style("cursor", "pointer")
+    .on("click", function (event, d) {
+      const index = dataSets.indexOf(d);
+      visibility[index] = !visibility[index];
+      d3.select(lines[index].node()).style(
+        "opacity",
+        visibility[index] ? 1 : 0,
+      );
+      d3.select(this).style("opacity", visibility[index] ? 1 : 0.5); // Adjust the legend item's opacity
+    });
+
+  // Function to dispatch a click event
+  function dispatchClick(element) {
+    const clickEvent = new MouseEvent("click", {
+      view: window,
+      bubbles: true,
+      cancelable: true,
+    });
+    element.dispatchEvent(clickEvent);
+  }
+
+  // Select all '.legend' group elements and click on all but the first three
+  svg.selectAll(".legend").each(function (d, i) {
+    if (!selectedIndexes.includes(i)) {
+      dispatchClick(this);
+    }
+  });
+
+  // Add colored rectangles to the legend.
+  legend
+    .append("rect")
+    .attr("x", -18)
+    .attr("width", 18)
+    .attr("height", 18)
+    .attr("fill", (d, i) => colors[i % colors.length]);
+
+  // Add text to the legend.
+  legend
+    .append("text")
+    .attr("x", -24)
+    .attr("y", 9)
+    .attr("dy", ".35em")
+    .attr("text-anchor", "end")
+    .text((d, i) => labels[i])
+    .attr("class", "legend-text");
+
+  // Append a vertical line to the chart, initially hidden
+  const verticalLine = svg
+    .append("line")
+    .style("stroke", "grey")
+    .style("stroke-width", "1px")
+    .style("stroke-dasharray", "3,3")
+    .style("display", "none"); // Initially hidden
+
+  // Create an overlay for the mouseover event
+  svg
+    .append("rect")
+    .attr("class", "overlay")
+    .attr("x", marginLeft)
+    .attr("y", marginTop)
+    .attr("width", width - marginLeft - marginRight)
+    .attr("height", height - marginTop - marginBottom)
+    .style("fill", "none")
+    .style("pointer-events", "all")
+    .on("mouseover", () => tooltip.style("display", null))
+    .on("mouseout", () => {
+      verticalLine.style("display", "none");
+      tooltip.style("display", "none");
+    })
+    .on("mousemove", mousemove);
+
+  // Function to handle mouse movements
+  function mousemove(event) {
+    const x0 = x.invert(d3.pointer(event)[0]),
+      formatDate = d3.timeFormat("%H:%M:%S");
+    const xPos = d3.pointer(event)[0];
+    tooltip
+      .attr("transform", `translate(${d3.pointer(event)[0]},0)`)
+      .call((g) => g.select("text").text(`${formatDate(x0)}`));
+
+    // Update the vertical line position
+    verticalLine
+      .attr("x1", xPos)
+      .attr("x2", xPos)
+      .attr("y1", marginTop)
+      .attr("y2", height - marginBottom)
+      .style("display", null);
+  }
+
+  // Create a tooltip for displaying the time
+  const tooltip = svg.append("g").style("display", "none");
+
+  tooltip
+    .append("text")
+    .attr("class", "tooltip-date")
+    .attr("y", marginTop - 4)
+    .attr("x", marginLeft)
+    .attr("text-anchor", "middle")
+    .attr("font-size", "12px")
+    .style("background", "white");
+
+  // Add buttons to the bottom of the legend
+  const buttons = svg
+    .append("g")
+    .attr(
+      "transform",
+      `translate(${width - marginRight + 20}, ${dataSets.length * 20 + 30})`,
+    );
+
+  // Add the previous button ("<")
+  buttons
+    .append("text")
+    .attr("class", "previous-button")
+    .attr("x", 0)
+    .attr("y", 30)
+    .attr("font-size", "12px")
+    .attr("text-anchor", "start")
+    .text("< Previous")
+    .style("cursor", "pointer")
+    .on("click", () => {
+      weeksAgo++;
+      updateChart(weeksAgo);
+    });
+
+  if (weeksAgo !== 0) {
+    // Add the next button (">")
+    buttons
+      .append("text")
+      .attr("class", "next-button")
+      .attr("x", 15)
+      .attr("y", 50)
+      .attr("font-size", "12px")
+      .attr("text-anchor", "start")
+      .text("Next >")
+      .style("cursor", "pointer")
+      .on("click", () => {
+        if (weeksAgo > 0) {
+          weeksAgo--;
+          updateChart(weeksAgo);
+        }
+      });
+  }
+
+  return svg.node();
 }
 
-function getStatsRecords(weeksAgo) {
-    const baseUrl = `api/stat-history/?weeks-ago=${weeksAgo}`;
+function convertDataForChart(data, keys) {
+  return keys.map((key) =>
+    data.map((d) => ({
+      date: new Date(d.timestamp),
+      value: d[key],
+    })),
+  );
+}
 
-    return fetch(baseUrl)
-        .then(response => {
-            if (!response.ok) {
-                throw new Error('Network response was not ok');
-            }
-            return response.json();
-        })
-        .catch(error => {
-            console.error('There was a problem with the fetch operation:', error.message);
-        });
+function getStatsRecords(statsUrl) {
+  return fetch(statsUrl)
+    .then((response) => {
+      if (!response.ok) {
+        throw new Error("Network response was not ok");
+      }
+      return response.json();
+    })
+    .catch((error) => {
+      console.error(
+        "There was a problem with the fetch operation:",
+        error.message,
+      );
+    });
+}
+
+function getCurrentSubprotocol() {
+  const url = new URL(window.location);
+  const subprotocolName = url.searchParams.get("network")
+    ? url.searchParams.get("network").toLowerCase()
+    : "history";
+
+  subprotocols = {
+    history: {
+      baseUrl: "api/stats-history/?weeks-ago=",
+      keys: [
+        "success_rate_all",
+        "success_rate_latest",
+        "success_rate_random",
+        "success_rate_four_fours",
+        "success_rate_all_headers",
+        "success_rate_all_bodies",
+        "success_rate_all_receipts",
+        "success_rate_latest_headers",
+        "success_rate_latest_bodies",
+        "success_rate_latest_receipts",
+        "success_rate_random_headers",
+        "success_rate_random_bodies",
+        "success_rate_random_receipts",
+        "success_rate_four_fours_headers",
+        "success_rate_four_fours_bodies",
+        "success_rate_four_fours_receipts",
+      ],
+      selectedIndexes: [3],
+      labels: [
+        "All",
+        "Latest",
+        "Random",
+        "4444s",
+        "All Headers",
+        "All Bodies",
+        "All Receipts",
+        "Latest Headers",
+        "Latest Bodies",
+        "Latest Receipts",
+        "Random Headers",
+        "Random Bodies",
+        "Random Receipts",
+        "4444s Headers",
+        "4444s Bodies",
+        "4444s Receipts",
+      ],
+    },
+    state: {
+      baseUrl: "api/stats-state/?weeks-ago=",
+      keys: [
+        "success_rate_state_all",
+        "success_rate_state_latest",
+        "success_rate_state_state_roots",
+      ],
+      selectedIndexes: [2],
+      labels: ["All", "Latest", "State Roots"],
+    },
+    beacon: {
+      baseUrl: "api/stats-beacon/?weeks-ago=",
+      keys: ["success_rate_beacon_all", "success_rate_beacon_latest"],
+      selectedIndexes: [1],
+      labels: ["All", "Latest"],
+    },
+  };
+
+  return subprotocols[subprotocolName];
 }
 
 async function updateChart(weeksAgo) {
-    const data = await getStatsRecords(weeksAgo);
+  const subprotocol = getCurrentSubprotocol();
+  const data = await getStatsRecords(subprotocol.baseUrl + weeksAgo);
 
-    let dataSets = convertDataForChart(data);
+  let dataSets = convertDataForChart(data, subprotocol.keys);
 
-    // Clear the existing chart
-    d3.select("#stats-history-graph").html("");
+  // Clear the existing chart
+  d3.select("#stats-history-graph").html("");
 
-    // Create a new chart with the updated data
-    if (dataSets && dataSets.length > 0) {
-        document.getElementById('stats-history-graph').appendChild(createMultiLineChart(400, 670, dataSets, weeksAgo));
-    } else {
-        console.log('No data available to plot the stats chart');
-    }
+  // Create a new chart with the updated data
+  if (dataSets && dataSets.length > 0) {
+    document
+      .getElementById("stats-history-graph")
+      .appendChild(
+        createMultiLineChart(
+          400,
+          670,
+          dataSets,
+          subprotocol.labels,
+          subprotocol.selectedIndexes,
+          weeksAgo,
+        ),
+      );
+  } else {
+    console.log("No data available to plot the stats chart");
+  }
 }
 
 async function statsHistoryChart() {
-    updateChart(weeksAgo);
+  updateChart(0);
 }

--- a/glados-web/src/lib.rs
+++ b/glados-web/src/lib.rs
@@ -91,7 +91,18 @@ pub async fn run_glados_web(config: Arc<State>) -> Result<()> {
             "/api/is-content-in-deadzone/:content_key",
             get(routes::is_content_in_deadzone),
         )
-        .route("/api/stat-history/", get(routes::get_audit_stats_handler))
+        .route(
+            "/api/stats-history/",
+            get(routes::get_history_audit_stats_handler),
+        )
+        .route(
+            "/api/stats-state/",
+            get(routes::get_state_audit_stats_handler),
+        )
+        .route(
+            "/api/stats-beacon/",
+            get(routes::get_beacon_audit_stats_handler),
+        )
         .route("/api/failed-keys/", get(routes::get_failed_keys_handler))
         .route(
             "/census/census-node-timeseries-data/",

--- a/glados-web/src/templates.rs
+++ b/glados-web/src/templates.rs
@@ -12,14 +12,16 @@ use entity::{
 use crate::routes::{
     CalculatedRadiusChartData, ClientDiversityResult, PaginatedCensusListResult, RawEnr,
 };
-use glados_core::stats::AuditStats;
+use glados_core::stats::{AuditStats, StrategyFilter};
 
 #[derive(Template)]
 #[template(path = "index.html")]
 pub struct IndexTemplate {
+    pub strategy: StrategyFilter,
     pub client_diversity_data: Vec<ClientDiversityResult>,
     pub average_radius_chart: Vec<CalculatedRadiusChartData>,
     pub stats: [AuditStats; 3],
+    pub new_content: [u32; 3],
 }
 
 #[derive(Template)]

--- a/glados-web/templates/index.html
+++ b/glados-web/templates/index.html
@@ -21,10 +21,22 @@
                 <div class="card-body">
                     <button class="question-mark" aria-label="Toggle explanation"></button>
                     <div class="explanation">
-                        Glados continuously queries the Portal network for random 4444s headers, blocks, and receipts.
-                        Statistical results of these audits are displayed here and can be viewed in more granular detail on the Audit Dashboard.
-                     </div>
-                    <h2>4444s stats</h2>
+                    {% match strategy %}
+                        {% when StrategyFilter::FourFours %}
+                            Glados continuously queries the Portal network for random 4444s headers, blocks, and receipts.
+                            Statistical results of these audits are displayed here and can be viewed in more granular detail on the Audit Dashboard.
+                        {% when StrategyFilter::StateRoots %}
+                            Glados continuously queries the Portal network for random state roots.
+                            Statistical results of these audits are displayed here and can be viewed in more granular detail on the Audit Dashboard.
+                        {% when StrategyFilter::Latest %}
+                            Glados continuously queries the Portal network recent beacon block roots.
+                            Statistical results of these audits are displayed here and can be viewed in more granular detail on the Audit Dashboard.
+                        {% else %}
+                            No explanation available for {{ strategy }}
+                    {% endmatch %}
+
+                    </div>
+                    <h2>{{ strategy }} stats</h2>
                     <div class="table-responsive">
                         <table class="table">
                             <thead>
@@ -43,7 +55,7 @@
                                 {% for stat in stats %}
                                 <tr>
                                     <th scope="row">{{ stat.period.to_string() }}</th>
-                                    <td>{{ stat.new_content }}</td>
+                                    <td>{{ new_content[loop.index0] }}</td>
                                     <td>{{ stat.total_audits }}</td>
                                     <td>{{ stat.total_passes }}</td>
                                     <td>{{ stat.total_failures }}</td>

--- a/migration/README.md
+++ b/migration/README.md
@@ -6,7 +6,7 @@ Install
 cargo install sea-orm-cli
 ```
 Create (if none already created) a new blank postgres instance:
-`docker run --name postgres -e POSTGRES_DB=glados POSTGRES_PASSWORD=password -d -p 5432:5432 postgres`
+`docker run --name postgres -e POSTGRES_DB=glados -e POSTGRES_PASSWORD=password -d -p 5432:5432 postgres`
 `export DATABASE_URL=postgres://postgres:password@localhost:5432/glados`
 ```
 Generate all entities. Commands are made from the project root directory.

--- a/migration/src/lib.rs
+++ b/migration/src/lib.rs
@@ -16,6 +16,7 @@ mod m20240720_111606_create_census_index;
 mod m20240814_121507_census_subnetwork;
 mod m20240919_121611_census_subnetwork_index;
 mod m20241010_151313_audit_stats_performance;
+mod m20241206_154045_add_beacon_and_state_audit_stats;
 
 pub struct Migrator;
 
@@ -39,6 +40,7 @@ impl MigratorTrait for Migrator {
             Box::new(m20240814_121507_census_subnetwork::Migration),
             Box::new(m20240919_121611_census_subnetwork_index::Migration),
             Box::new(m20241010_151313_audit_stats_performance::Migration),
+            Box::new(m20241206_154045_add_beacon_and_state_audit_stats::Migration),
         ]
     }
 }

--- a/migration/src/m20241206_154045_add_beacon_and_state_audit_stats.rs
+++ b/migration/src/m20241206_154045_add_beacon_and_state_audit_stats.rs
@@ -1,0 +1,67 @@
+use sea_orm_migration::prelude::*;
+
+#[derive(DeriveMigrationName)]
+pub struct Migration;
+
+#[async_trait::async_trait]
+impl MigrationTrait for Migration {
+    async fn up(&self, manager: &SchemaManager) -> Result<(), DbErr> {
+        manager
+            .alter_table(
+                Table::alter()
+                    .table(AuditStats::Table)
+                    .add_column_if_not_exists(
+                        ColumnDef::new(AuditStats::SuccessRateStateAll)
+                            .float()
+                            .default(0.0),
+                    )
+                    .add_column_if_not_exists(
+                        ColumnDef::new(AuditStats::SuccessRateStateLatest)
+                            .float()
+                            .default(0.0),
+                    )
+                    .add_column_if_not_exists(
+                        ColumnDef::new(AuditStats::SuccessRateStateStateRoots)
+                            .float()
+                            .default(0.0),
+                    )
+                    .add_column_if_not_exists(
+                        ColumnDef::new(AuditStats::SuccessRateBeaconAll)
+                            .float()
+                            .default(0.0),
+                    )
+                    .add_column_if_not_exists(
+                        ColumnDef::new(AuditStats::SuccessRateBeaconLatest)
+                            .float()
+                            .default(0.0),
+                    )
+                    .to_owned(),
+            )
+            .await
+    }
+
+    async fn down(&self, manager: &SchemaManager) -> Result<(), DbErr> {
+        manager
+            .alter_table(
+                Table::alter()
+                    .table(AuditStats::Table)
+                    .drop_column(AuditStats::SuccessRateStateAll)
+                    .drop_column(AuditStats::SuccessRateStateLatest)
+                    .drop_column(AuditStats::SuccessRateStateStateRoots)
+                    .drop_column(AuditStats::SuccessRateBeaconAll)
+                    .drop_column(AuditStats::SuccessRateBeaconLatest)
+                    .to_owned(),
+            )
+            .await
+    }
+}
+
+#[derive(Iden)]
+enum AuditStats {
+    Table,
+    SuccessRateStateAll,
+    SuccessRateStateLatest,
+    SuccessRateStateStateRoots,
+    SuccessRateBeaconAll,
+    SuccessRateBeaconLatest,
+}


### PR DESCRIPTION
Display State and Beacon data (when those subprotocols are selected) both in the Stats table and Audit Success chart of the main Glados Dashboard


Pending:
- [x] Changes the response Type of `/api/hourly-success-rate/` (removes `new_content`), are consumers affected by this?
- [x] Write tooltip explanations of new State and Beacon stats