### PR TITLE
chore: upgrade ethportal-api to latest

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -418,15 +418,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "ansi_term"
-version = "0.12.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d52a9bb7ec0cf484c551830a7ce27bd20d67eac647e1befb56b0be4ee39a55d2"
-dependencies = [
- "winapi",
-]
-
-[[package]]
 name = "anstream"
 version = "0.6.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -862,17 +853,6 @@ name = "atomic-waker"
 version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
-
-[[package]]
-name = "atty"
-version = "0.2.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9b39be18770d11421cdb1b9947a45dd3f37e93092cbf377614828a319d5fee8"
-dependencies = [
- "hermit-abi 0.1.19",
- "libc",
- "winapi",
-]
 
 [[package]]
 name = "auto_impl"
@@ -1700,15 +1680,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "directories"
-version = "3.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e69600ff1703123957937708eb27f7a564e48885c537782722ed0ba3189ce1d7"
-dependencies = [
- "dirs-sys",
-]
-
-[[package]]
 name = "dirs"
 version = "4.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1926,8 +1897,9 @@ dependencies = [
 
 [[package]]
 name = "eth_trie"
-version = "0.4.0"
-source = "git+https://github.com/ethereum/eth-trie.rs?tag=v0.1.0-alpha.2#46da867d8a7eace0a9e912271b236b2007e4cd41"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f7ffb0d2fa42ad87f02c0683c04b31cb41bf3853f2327d037738345bc5b56671"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -2028,8 +2000,8 @@ dependencies = [
 
 [[package]]
 name = "ethportal-api"
-version = "0.2.2"
-source = "git+https://github.com/ethereum/trin?rev=0b5f04364478cd4ea0aadebb41e6681f55640934#0b5f04364478cd4ea0aadebb41e6681f55640934"
+version = "0.3.0"
+source = "git+https://github.com/ethereum/trin?rev=580a72b9a0c059af82b67c7da7c8bd56ddb41ad2#580a72b9a0c059af82b67c7da7c8bd56ddb41ad2"
 dependencies = [
  "alloy",
  "alloy-rlp",
@@ -2063,13 +2035,13 @@ dependencies = [
  "serde_json",
  "sha2",
  "sha3 0.9.1",
+ "shadow-rs",
  "ssz_types",
  "superstruct",
  "thiserror",
  "tokio",
  "tree_hash",
  "tree_hash_derive",
- "trin-utils",
  "ureq",
  "url",
  "validator",
@@ -2757,15 +2729,6 @@ checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
 name = "hermit-abi"
-version = "0.1.19"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62b467343b94ba476dcb2500d242dadbb39557df889310ac77c5d99100aaac33"
-dependencies = [
- "libc",
-]
-
-[[package]]
-name = "hermit-abi"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d231dfb89cfffdbc30e7fc41579ed6066ad03abda9e567ccafae602b97ec5024"
@@ -3138,7 +3101,7 @@ version = "1.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eae7b9aee968036d54dce06cebaefd919e4472e753296daccd6d344e3e2df0c2"
 dependencies = [
- "hermit-abi 0.3.9",
+ "hermit-abi",
  "libc",
  "windows-sys 0.48.0",
 ]
@@ -3155,7 +3118,7 @@ version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f23ff5ef2b80d608d61efee834934d862cd92461afc0560dedf493e4c033738b"
 dependencies = [
- "hermit-abi 0.3.9",
+ "hermit-abi",
  "libc",
  "windows-sys 0.52.0",
 ]
@@ -3716,16 +3679,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "nu-ansi-term"
-version = "0.46.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77a8165726e8236064dbb45459242600304b42a5ea24ee2948e18e023bf7ba84"
-dependencies = [
- "overload",
- "winapi",
-]
-
-[[package]]
 name = "num-bigint"
 version = "0.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3766,7 +3719,7 @@ version = "1.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4161fcb6d602d4d2081af7c3a45852d875a03dd337a6bfdd6e06407b61342a43"
 dependencies = [
- "hermit-abi 0.3.9",
+ "hermit-abi",
  "libc",
 ]
 
@@ -3872,12 +3825,6 @@ dependencies = [
  "quote",
  "syn 1.0.109",
 ]
-
-[[package]]
-name = "overload"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b15813163c1d831bf4a13c3610c05c0d03b39feb07f7e09fa234dac9b15aaf39"
 
 [[package]]
 name = "parity-scale-codec"
@@ -4109,7 +4056,7 @@ checksum = "645493cf344456ef24219d02a768cf1fb92ddf8c92161679ae3d91b91a637be3"
 dependencies = [
  "cfg-if",
  "concurrent-queue",
- "hermit-abi 0.3.9",
+ "hermit-abi",
  "pin-project-lite",
  "rustix 0.38.34",
  "tracing",
@@ -6018,18 +5965,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c06d3da6113f116aaee68e4d601191614c9053067f9ab7f6edbcb161237daa54"
 dependencies = [
  "once_cell",
- "valuable",
-]
-
-[[package]]
-name = "tracing-log"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ee855f1f400bd0e5c02d150ae5de3840039a3f54b025156404e34c23c03f47c3"
-dependencies = [
- "log",
- "once_cell",
- "tracing-core",
 ]
 
 [[package]]
@@ -6039,15 +5974,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ad0f048c97dbd9faa9b7df56362b8ebcaa52adb06b498c050d2f4e32f90a7a8b"
 dependencies = [
  "matchers",
- "nu-ansi-term",
  "once_cell",
  "regex",
  "sharded-slab",
- "smallvec",
  "thread_local",
  "tracing",
  "tracing-core",
- "tracing-log",
 ]
 
 [[package]]
@@ -6071,20 +6003,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.79",
-]
-
-[[package]]
-name = "trin-utils"
-version = "0.1.1-alpha.1"
-source = "git+https://github.com/ethereum/trin?rev=0b5f04364478cd4ea0aadebb41e6681f55640934#0b5f04364478cd4ea0aadebb41e6681f55640934"
-dependencies = [
- "ansi_term",
- "atty",
- "directories",
- "shadow-rs",
- "tempfile",
- "tracing",
- "tracing-subscriber",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,7 @@ clap = { version = "4.0.26", features = ["derive"] }
 enr = "0.10.0"
 entity = { path = "entity" }
 env_logger = "0.10.0"
-ethportal-api = { git = "https://github.com/ethereum/trin", rev = "0b5f04364478cd4ea0aadebb41e6681f55640934" }
+ethportal-api = { git = "https://github.com/ethereum/trin", rev = "580a72b9a0c059af82b67c7da7c8bd56ddb41ad2" }
 glados-core = { path = "glados-core" }
 glados-monitor = { path = "glados-monitor" }
 glados-audit = { path = "glados-audit" }

--- a/glados-audit/Cargo.toml
+++ b/glados-audit/Cargo.toml
@@ -17,7 +17,7 @@ entity.workspace = true
 env_logger.workspace= true
 pgtemp.workspace = true
 enr.workspace = true
-eth_trie = { tag = "v0.1.0-alpha.2", git = "https://github.com/ethereum/eth-trie.rs" }
+eth_trie = "0.5.0"
 web3.workspace= true
 ethportal-api.workspace = true
 glados-core.workspace = true

--- a/glados-web/src/routes.rs
+++ b/glados-web/src/routes.rs
@@ -32,12 +32,9 @@ use sea_orm::{
     LoaderTrait, ModelTrait, QueryFilter, QueryOrder, QuerySelect,
 };
 use serde::Serialize;
+use std::collections::{HashMap, HashSet};
 use std::fmt::Formatter;
 use std::sync::Arc;
-use std::{
-    collections::{HashMap, HashSet},
-    time::UNIX_EPOCH,
-};
 use std::{fmt::Display, io};
 use tracing::{error, info, warn};
 
@@ -558,13 +555,10 @@ pub async fn contentaudit_detail(
     // If we were able to deserialize the trace, we can look up & interpolate the radius for the nodes in the trace.
     if let Some(trace) = &mut trace {
         // Get the timestamp of the query
-        let query_timestamp = trace.started_at_ms;
-        let timestamp: DateTime<Utc> = {
-            let duration = query_timestamp.duration_since(UNIX_EPOCH).unwrap();
-            Utc.timestamp_opt(duration.as_secs() as i64, duration.subsec_nanos())
-                .single()
-                .expect("Failed to convert timestamp to DateTime")
-        };
+        let timestamp: DateTime<Utc> = Utc
+            .timestamp_millis_opt(trace.started_at_ms as i64)
+            .single()
+            .expect("Failed to convert timestamp to DateTime");
 
         // Do a query to get, for each node, the radius recorded closest to the time at which the trace took place.
         let node_ids: Vec<Vec<u8>> = trace


### PR DESCRIPTION
It uses a more recent version of eth-trie, which causes conflict errors with the locally imported version. Updating the local version is apparently trivial.

This is necessary to use the latest versions of trin.