### PR TITLE
chore: pin postgres to version 16.4 in docker

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,7 +2,7 @@ version: '3'
 services:
 
   glados_postgres:
-    image: postgres:latest
+    image: postgres:16.4
     environment:
       POSTGRES_USER: postgres
       POSTGRES_PASSWORD: ${GLADOS_POSTGRES_PASSWORD?Glados Postgres Password Required}


### PR DESCRIPTION
It was pinned like this on the production server. I have no other context for it.

Obviously we want to avoid having any production patches at all (among other things, it prevents deploying via ansible), so even if it's a short term fix for something, let's put the change in master.