### PR TITLE
feat: Pass Beacon base URL to Beacon Monitor

### DIFF
--- a/glados-monitor/src/cli.rs
+++ b/glados-monitor/src/cli.rs
@@ -28,6 +28,12 @@ pub enum Commands {
         provider_url: String,
     },
 
+    FollowBeacon {
+        // Beacon node base URL
+        #[arg(short, long)]
+        beacon_base_url: String,
+    },
+
     FollowBeaconPandaops {},
 
     /// Imports blocks from a remote provider

--- a/glados-monitor/src/lib.rs
+++ b/glados-monitor/src/lib.rs
@@ -39,8 +39,12 @@ pub async fn run_glados_monitor(conn: DatabaseConnection, w3: web3::Web3<web3::t
     info!("got CTRL+C. shutting down...");
 }
 
-pub async fn run_glados_monitor_beacon(conn: DatabaseConnection, client: HttpClient) {
-    tokio::spawn(follow_beacon_head(conn, client));
+pub async fn run_glados_monitor_beacon(
+    conn: DatabaseConnection,
+    client: HttpClient,
+    beacon_url: String,
+) {
+    tokio::spawn(follow_beacon_head(conn, client, beacon_url));
 
     debug!("setting up CTRL+C listener");
     tokio::signal::ctrl_c()


### PR DESCRIPTION
Currently the Beacon Monitor is hardcoded to use the ethPandaOps beacon node. This PR adds a new monitor command `follow-beacon` which receives `--beacon-base-url` allowing use of any beacon node.

The beacon nodes passed through `--beacon-base-url` may use HTTP basic authentication if the username and password are passed as part of the URL. Using environment variables for authentication can be added if needed.