### PR TITLE
fix: increase audit chart tooltip visibility

### DIFF
--- a/glados-web/assets/js/stats_history.js
+++ b/glados-web/assets/js/stats_history.js
@@ -184,7 +184,7 @@ function createMultiLineChart(height, width, dataSets) {
 
     tooltip.append("text")
         .attr("class", "tooltip-date")
-        .attr("y", marginTop / 2)
+        .attr("y", marginTop - 4)
         .attr("x", marginLeft)
         .attr("text-anchor", "middle")
         .attr("font-size", "12px")


### PR DESCRIPTION
The weekly audit chart has a tooltip when you hover, showing you the time. This time overlapped the chart title, making it difficult to read. I just tweaked the y-value in my browser until I was happy that it didn't overlap the chart or the title.