### PR TITLE
feat: Persist bootnodes in census explorer

### DIFF
--- a/entity/src/node.rs
+++ b/entity/src/node.rs
@@ -844,4 +844,11 @@ lazy_static! {
 
         nicknames
     };
+    pub static ref BOOTNODE_NICKNAMES: HashMap<String, String> = {
+        NODE_NICKNAME_MAP
+            .iter()
+            .filter(|(_, nickname)| nickname.contains("bootnode"))
+            .map(|(id, nickname)| (id.clone(), nickname.clone()))
+            .collect()
+    };
 }


### PR DESCRIPTION
Display bootnodes in census explorer even if they have not been seen during the reported 24 hour period