### PR TITLE
feat: Add census weekly graph

### DIFF
--- a/glados-web/assets/js/census_weekly.js
+++ b/glados-web/assets/js/census_weekly.js
@@ -1,0 +1,268 @@
+function createMultiLineChart(
+  height,
+  width,
+  dataSets,
+  weeksAgo,
+  labels = null,
+  selectedIndexes = null,
+) {
+  // Declare the chart dimensions and margins.
+  const marginTop = 40;
+  const marginRight = 50;
+  const marginBottom = 20;
+  const marginLeft = 40;
+
+  // Parse dates if they're not already Date objects
+  dataSets.forEach((dataset) => {
+    dataset.forEach((d) => {
+      if (!(d.date instanceof Date)) d.date = new Date(d.date);
+    });
+  });
+
+  // Declare the x (horizontal position) scale.
+  const x = d3
+    .scaleTime()
+    .domain(d3.extent(dataSets.flat(), (d) => d.date))
+    .range([marginLeft, width - marginRight]);
+
+  // Color palette for the lines.
+  const colors = d3.schemeTableau10;
+
+  // Create the SVG container.
+  const svg = d3
+    .create("svg")
+    .attr("width", width)
+    .attr("height", height)
+    .attr("viewBox", [0, 0, width, height])
+    .attr("overflow", "visible")
+    .attr("style", "max-width: 100%; height: auto; height: intrinsic;");
+
+  // Add the x-axis.
+  svg
+    .append("g")
+    .attr("transform", `translate(0,${height - marginBottom})`)
+    .call(
+      d3
+        .axisBottom(x)
+        .ticks(width / 80)
+        .tickSizeOuter(0),
+    );
+
+  // Add Y axis
+  // Declare the y (vertical position) scale.
+  const y = d3
+    .scaleLinear()
+    .domain([
+      d3.min(dataSets.flat(), (d) => d.value) * 0.99,
+      d3.max(dataSets.flat(), (d) => d.value) * 1.01,
+    ])
+    .range([height - marginBottom, marginTop]);
+
+  svg
+    .append("g")
+    .attr("transform", `translate(${marginLeft} ,0)`)
+    .call(d3.axisLeft(y))
+    .call((g) =>
+      g
+        .selectAll(".tick line")
+        .clone()
+        .attr("x2", width - marginLeft - marginRight)
+        .attr("stroke-opacity", 0.1),
+    )
+    .call((g) =>
+      g
+        .append("text")
+        .attr("x", -marginLeft)
+        .attr("y", 10)
+        .attr("fill", "currentColor")
+        .attr("text-anchor", "start")
+        .text("# of nodes"),
+    );
+
+  // Add title
+  svg
+    .append("text")
+    .attr("class", "graph-title")
+    .attr("text-anchor", "middle")
+    .attr("x", width / 2)
+    .attr("y", marginTop / 2)
+    .text("Nodes in Census, by week");
+
+  // Add lines to the graph.
+  const lines = dataSets.map((dataSet, i) => {
+    const line = d3
+      .line()
+      .defined((d) => !isNaN(d.value))
+      .x((d) => x(d.date))
+      .y((d) => y(d.value));
+
+    return svg
+      .append("path")
+      .datum(dataSet)
+      .attr("fill", "none")
+      .attr("stroke", colors[i % colors.length])
+      .attr("stroke-width", 1.5)
+      .attr("d", line)
+      .attr("class", `line line-${i}`);
+  });
+
+  // Append a vertical line to the chart, initially hidden
+  const verticalLine = svg
+    .append("line")
+    .style("stroke", "grey")
+    .style("stroke-width", "1px")
+    .style("stroke-dasharray", "3,3")
+    .style("display", "none"); // Initially hidden
+
+  // Create an overlay for the mouseover event
+  svg
+    .append("rect")
+    .attr("class", "overlay")
+    .attr("x", marginLeft)
+    .attr("y", marginTop)
+    .attr("width", width - marginLeft - marginRight)
+    .attr("height", height - marginTop - marginBottom)
+    .style("fill", "none")
+    .style("pointer-events", "all")
+    .on("mouseover", () => tooltip.style("display", null))
+    .on("mouseout", () => {
+      verticalLine.style("display", "none");
+      tooltip.style("display", "none");
+    })
+    .on("mousemove", mousemove);
+
+  // Function to handle mouse movements
+  function mousemove(event) {
+    const x0 = x.invert(d3.pointer(event)[0]),
+      formatDate = d3.timeFormat("%H:%M:%S");
+    const xPos = d3.pointer(event)[0];
+    tooltip
+      .attr("transform", `translate(${d3.pointer(event)[0]},0)`)
+      .call((g) => g.select("text").text(`${formatDate(x0)}`));
+
+    // Update the vertical line position
+    verticalLine
+      .attr("x1", xPos)
+      .attr("x2", xPos)
+      .attr("y1", marginTop)
+      .attr("y2", height - marginBottom)
+      .style("display", null);
+  }
+
+  // Create a tooltip for displaying the time
+  const tooltip = svg.append("g").style("display", "none");
+
+  tooltip
+    .append("text")
+    .attr("class", "tooltip-date")
+    .attr("y", marginTop - 4)
+    .attr("x", marginLeft)
+    .attr("text-anchor", "middle")
+    .attr("font-size", "12px")
+    .style("background", "white");
+
+  // Add buttons to the bottom of the legend
+  const buttons = svg
+    .append("g")
+    .attr(
+      "transform",
+      `translate(${width - marginRight + 20}, ${dataSets.length * 20 + 30})`,
+    );
+
+  // Add the previous button ("<")
+  buttons
+    .append("text")
+    .attr("class", "previous-button")
+    .attr("x", 0)
+    .attr("y", 30)
+    .attr("font-size", "12px")
+    .attr("text-anchor", "start")
+    .text("< Previous")
+    .style("cursor", "pointer")
+    .on("click", () => {
+      weeksAgo++;
+      updateChart(weeksAgo);
+    });
+
+  if (weeksAgo !== 0) {
+    // Add the next button (">")
+    buttons
+      .append("text")
+      .attr("class", "next-button")
+      .attr("x", 15)
+      .attr("y", 50)
+      .attr("font-size", "12px")
+      .attr("text-anchor", "start")
+      .text("Next >")
+      .style("cursor", "pointer")
+      .on("click", () => {
+        if (weeksAgo > 0) {
+          weeksAgo--;
+          updateChart(weeksAgo);
+        }
+      });
+  }
+
+  return svg.node();
+}
+
+function convertDataForChart(data) {
+  return data.map((d) => ({
+    date: new Date(d.start),
+    value: d.nodeCount,
+  }));
+}
+
+function getStatsRecords(statsUrl) {
+  return fetch(statsUrl)
+    .then((response) => {
+      if (!response.ok) {
+        throw new Error("Network response was not ok");
+      }
+      return response.json();
+    })
+    .catch((error) => {
+      console.error(
+        "There was a problem with the fetch operation:",
+        error.message,
+      );
+    });
+}
+
+function getCurrentSubprotocolName() {
+  const url = new URL(window.location);
+  const subprotocolName = url.searchParams.get("network")
+    ? url.searchParams.get("network").toLowerCase()
+    : "history";
+
+  return subprotocolName;
+}
+
+async function updateChart(weeksAgo) {
+  const subprotocolName = getCurrentSubprotocolName();
+  const BASE_URL = "/api/census-weekly/?";
+
+  let params = new URLSearchParams();
+  params.append("network", subprotocolName);
+  params.append("weeks-ago", weeksAgo);
+
+  const data = await getStatsRecords(BASE_URL + params);
+
+  let dataSets = [convertDataForChart(data)];
+
+  // Clear the existing chart
+  d3.select("#census-weekly-graph").html("");
+
+  // Create a new chart with the updated data
+  if (dataSets && dataSets.length > 0) {
+    document
+      .getElementById("census-weekly-graph")
+      .appendChild(createMultiLineChart(425, 1060, dataSets, weeksAgo));
+  } else {
+    console.log("No data available to plot the stats chart");
+  }
+}
+
+export var censusWeeklyChart = async function () {
+  updateChart(0);
+};

--- a/glados-web/src/lib.rs
+++ b/glados-web/src/lib.rs
@@ -93,6 +93,7 @@ pub async fn run_glados_web(config: Arc<State>) -> Result<()> {
         )
         .route("/api/stat-history/", get(routes::get_audit_stats_handler))
         .route("/api/failed-keys/", get(routes::get_failed_keys_handler))
+        .route("/api/census-weekly/", get(routes::weekly_census_history))
         .route(
             "/census/census-node-timeseries-data/",
             get(routes::census_timeseries),

--- a/glados-web/src/routes.rs
+++ b/glados-web/src/routes.rs
@@ -1088,6 +1088,54 @@ fn decouple_nodes_and_censuses(
     (node_ids, censuses)
 }
 
+#[derive(Debug, Clone, Serialize, FromQueryResult)]
+#[serde(rename_all = "camelCase")]
+pub struct CensusHistoryData {
+    census_id: i32,
+    start: DateTime<Utc>,
+    node_count: i64,
+}
+pub async fn weekly_census_history(
+    http_args: HttpQuery<HashMap<String, String>>,
+    Extension(state): Extension<Arc<State>>,
+) -> Result<Json<Vec<CensusHistoryData>>, StatusCode> {
+    let weeks_ago: i32 = match http_args.get("weeks-ago") {
+        None => 0,
+        Some(days_ago) => days_ago.parse::<i32>().unwrap_or(0),
+    };
+
+    let subprotocol = get_subprotocol_from_params(&http_args);
+
+    let census_history: Vec<CensusHistoryData> =
+        CensusHistoryData::find_by_statement(Statement::from_sql_and_values(
+            DbBackend::Postgres,
+            "
+            SELECT
+                census.id AS census_id,
+                census.started_at AS start,
+                COUNT(1) AS node_count
+            FROM census
+            LEFT JOIN census_node ON census.id = census_node.census_id
+            WHERE
+                census.sub_network = $2 AND
+                started_at >= NOW() - INTERVAL '1 day' * ($1 + 1) AND
+                started_at < NOW() - INTERVAL '1 day' * $1
+            GROUP BY
+              census.id,
+              census.started_at
+            ORDER BY census.started_at
+        ",
+            vec![weeks_ago.into(), subprotocol.into()],
+        ))
+        .all(&state.database_connection)
+        .await
+        .map_err(|e| {
+            error!(err=?e, "Failed to lookup census node timeseries data");
+            StatusCode::INTERNAL_SERVER_ERROR
+        })?;
+    Ok(Json(census_history))
+}
+
 pub async fn single_census_view(
     params: HttpQuery<HashMap<String, String>>,
     Extension(state): Extension<Arc<State>>,

--- a/glados-web/templates/index.html
+++ b/glados-web/templates/index.html
@@ -98,7 +98,7 @@
                     <button class="question-mark" aria-label="Toggle explanation"></button>
                     <div class="explanation">
                         This graph shows a week's worth of success rate statistics for the various audits that Glados runs,
-                        as well as for the types of content that it audits. 
+                        as well as for the types of content that it audits.
                     </div>
                     <div id="stats-history-graph"> </div>
                 </div>
@@ -136,6 +136,19 @@
                 </div>
             </div>
         </div>
+        <div class="col-lg-13 col-md-18 col-sm-18 margin-bottom">
+            <div class="card pie-box h-100">
+                <div class="card-body">
+                    <button class="question-mark" aria-label="Toggle explanation"></button>
+                    <div class="explanation">
+                        This graph shows the amount of nodes that were reachable at each census (every 15 minutes).
+                    </div>
+                    <div class="table-responsive">
+                        <div id="census-weekly-graph"></div>
+                    </div>
+                </div>
+            </div>
+        </div>
     </div>
 
 </div>
@@ -145,6 +158,11 @@
     radius_node_id_scatter_chart(census_data);
     radius_stacked_chart(census_data);
     statsHistoryChart();
+
+</script>
+<script type="module">
+    import {censusWeeklyChart} from "../static/js/census_weekly.js";
+    censusWeeklyChart();
 </script>
 
 {% endblock %}


### PR DESCRIPTION
Add a graph showing the weekly count of nodes in each census to the network stats page.

A couple of questions:
- [ ] The js code is imported as a module to prevent shadowing functions of other graphs. Is this OK?
  - [ ] Should the same approach be applied to all graph js files?
- [ ] What display width should the graphs be optimized for?