### PR TITLE
fix: Add color to Census Explorer Stroke 

### DIFF
--- a/glados-web/assets/js/censustimeseries.js
+++ b/glados-web/assets/js/censustimeseries.js
@@ -148,7 +148,8 @@ function createSquareChart(width, data) {
                 .attr("y", y(node.nodeId))
                 .attr("width", `${(width * 0.96) / data.censuses.length}px`)
                 .attr("height", y.bandwidth() + "px")
-                .attr("stroke-width", 1)
+                .attr("stroke-width", 0.1)
+                .attr("stroke", "rgb(245, 245, 245)")
                 .attr("fill", censusResult ? "green" : "gray");
 
             let title = "";


### PR DESCRIPTION
Fixes #290, Firefox seems to handle transparent stroke differently than Webkit/Blink. The solution was to add color to the stroke (used the background color).

The stroke width also needed to be reduced, otherwise the strokes where to wide.