### PR TITLE
fix(web): false negative failures on dashboard

### DIFF
--- a/glados-core/src/stats.rs
+++ b/glados-core/src/stats.rs
@@ -108,6 +108,9 @@ pub async fn get_audit_stats(
         .count(conn)
         .await? as u32;
 
+    // In case the numbers change in between queries, make sure passes don't exceed total audits
+    let total_passes = std::cmp::min(total_passes, total_audits);
+
     let total_failures = total_audits - total_passes;
 
     let audits_per_minute = (60 * total_audits)


### PR DESCRIPTION
Sometimes, the number of audit successes exceeded the number of total audits in the dashboard.* When this happens, the number of failures underflows and ends up being near u32::MAX. This shows a huge failure percentage on the dashboard.

Now, the number of successes is clamped, so that they never exceed the total count (which makes the failure count never "negative" and prevents underflows).

* One could imagine this happening when a successful record is added to the database in between the query for the total and for the number of successful audits. If this was the main cause, it would probably happen irregularly and sporadically. Oddly, this bug seemed to happen quite consistently, like all day for days, and then not at all for days. So perhaps some other cause is at play.