### PR TITLE
Remove mandatory PANDAOPS ENV from docker-compose

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,8 +7,6 @@ services:
       POSTGRES_USER: postgres
       POSTGRES_PASSWORD: ${GLADOS_POSTGRES_PASSWORD?Glados Postgres Password Required}
       POSTGRES_DB: glados
-      PANDAOPS_ID: ${GLADOS_PANDAOPS_ID?Glados Pandaops ID Required}
-      PANDAOPS_SECRET: ${GLADOS_PANDAOPS_SECRET?Glados Pandaops Secret Required}
     volumes:
       - ${GLADOS_POSTGRES_DATA_DIR?Glados Postgres Data Directory Required}:/var/lib/postgresql/data
     ports:
@@ -96,8 +94,6 @@ services:
     image: portalnetwork/glados-monitor:latest
     environment:
       RUST_LOG: warn,glados_monitor=info
-      PANDAOPS_CLIENT_ID: ${GLADOS_PANDAOPS_ID?Glados Pandaops ID Required}
-      PANDAOPS_CLIENT_SECRET: ${GLADOS_PANDAOPS_SECRET?Glados Pandaops Secret Required}
     depends_on:
       - glados_audit
       - glados_postgres


### PR DESCRIPTION
This is in order to allow for running the docker compose setup with non PANDAOPS infrastructure.

Else one has to specifically set:
export GLADOS_PANDAOPS_SECRET=""
export GLADOS_PANDAOPS_ID=""

This is not good UX.