### PR TITLE
Enable discovery v5 JSON-RPC namespace for Fluffy client

### DIFF
--- a/docker-compose-clients.yml
+++ b/docker-compose-clients.yml
@@ -6,4 +6,4 @@ services:
     command: "--web3-transport http --web3-http-address http://0.0.0.0:8545/ --mb 0 --portal-subnetworks history,state,beacon --no-upnp --disable-poke ${GLADOS_CLIENT_ARGUMENTS:-}"
   fluffy:
     image: statusim/nimbus-fluffy:amd64-master-latest
-    command: "--rpc --rpc-address=0.0.0.0 --storage-capacity=0 --disable-poke ${GLADOS_CLIENT_ARGUMENTS:-}"
+    command: "--rpc --rpc-address=0.0.0.0 --rpc-api:eth,portal,discovery --storage-capacity=0 --disable-poke ${GLADOS_CLIENT_ARGUMENTS:-}"


### PR DESCRIPTION
We default disable discv5 json-rpc a while back, not realizing that this is mandatory in glados usage. This PR enables it specifically on cli.