### PR TITLE
feat: make node_id clickable on contentaudit_details page

### DIFF
--- a/glados-web/assets/js/trace/main.js
+++ b/glados-web/assets/js/trace/main.js
@@ -231,7 +231,7 @@ function generateTable(nodes) {
         let tr = document.createElement("tr");
         tr.innerHTML = `<th scope="row">${index + 1}</th>
             <td>${enr_shortened}</td>
-            <td>${nodeIdString}</td>
+            <td><a href="/network/node/${node.id}/">${nodeIdString}</a></td>
             <td>${node.distanceLog2}</td>
             <td>${node.ip}:${node.port}</td>
             <td>${node.client === undefined ? "" : node.client}</td>


### PR DESCRIPTION
This PR makes the 
![image](https://github.com/user-attachments/assets/a488df26-8e49-49e6-88ff-63d6f30325fa) (This PR doesn't include this change, I am just showing where it will be)
node id's in the contentaudit_detail.html page clickable so you can see more information about the node