### PR TITLE
feat: add premerge.csv header mappings to lfs

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+datasets/mainnet/blocks/premerge.csv filter=lfs diff=lfs merge=lfs -text

--- a/datasets/mainnet/blocks/premerge.csv
+++ b/datasets/mainnet/blocks/premerge.csv
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:fd63fd1b64233680eecbdc3903c951f9eea7ea43c366e5421fe62106039c5ed1
+size 1573702998


### PR DESCRIPTION
`datasets/mainnet/blocks/premerge.csv` contains mappings of hash to block number so that we don't have to look them up continuously