### PR TITLE
chore: remove PANDAOPS ENV variables from docker compose

### DIFF
--- a/DOCKER_GUIDE.md
+++ b/DOCKER_GUIDE.md
@@ -15,6 +15,8 @@ where Postgres should store its data on the host machine.
 
 - `GLADOS_PROVIDER_URL` to the execution API provider URL.
 
+- `GLADOS_BEACON_PROVIDER_URL` to the beacon API provider URL.
+
 - `GLADOS_PORTAL_CLIENT` to the Portal client to be used for Portal network
 access. Currently supported values are `trin` and `fluffy`.
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,8 +7,6 @@ services:
       POSTGRES_USER: postgres
       POSTGRES_PASSWORD: ${GLADOS_POSTGRES_PASSWORD?Glados Postgres Password Required}
       POSTGRES_DB: glados
-      PANDAOPS_ID: ${GLADOS_PANDAOPS_ID?Glados Pandaops ID Required}
-      PANDAOPS_SECRET: ${GLADOS_PANDAOPS_SECRET?Glados Pandaops Secret Required}
     volumes:
       - ${GLADOS_POSTGRES_DATA_DIR?Glados Postgres Data Directory Required}:/var/lib/postgresql/data
     ports:
@@ -92,12 +90,10 @@ services:
     restart: always
 
   glados_monitor_beacon:
-    command: "--database-url postgres://postgres:${GLADOS_POSTGRES_PASSWORD}@glados_postgres:5432/glados follow-beacon-pandaops"
+    command: "--database-url postgres://postgres:${GLADOS_POSTGRES_PASSWORD}@glados_postgres:5432/glados follow-beacon --beacon-base-url ${GLADOS_BEACON_PROVIDER_URL?Glados monitor beacon provider URL required}"
     image: portalnetwork/glados-monitor:latest
     environment:
       RUST_LOG: warn,glados_monitor=info
-      PANDAOPS_CLIENT_ID: ${GLADOS_PANDAOPS_ID?Glados Pandaops ID Required}
-      PANDAOPS_CLIENT_SECRET: ${GLADOS_PANDAOPS_SECRET?Glados Pandaops Secret Required}
     depends_on:
       - glados_audit
       - glados_postgres


### PR DESCRIPTION
Expanding on PR #356 to include a change and documentation on how to run the beacon monitor with a custom beacon node API