### PR TITLE
chore(web): display headers by number for latest block status graph

### DIFF
--- a/entity/src/audit_result_latest.rs
+++ b/entity/src/audit_result_latest.rs
@@ -26,12 +26,14 @@ use crate::content_audit::AuditResult;
 #[sea_orm(rs_type = "u8", db_type = "Integer")]
 #[strum(serialize_all = "snake_case")]
 pub enum ContentType {
-    #[strum(message = "Block header by hash")]
-    BlockHeaderByHash = 0,
-    #[strum(message = "Block body")]
-    BlockBody = 1,
+    #[strum(message = "Block headers by hash")]
+    BlockHeadersByHash = 0,
+    #[strum(message = "Block bodies")]
+    BlockBodies = 1,
     #[strum(message = "Block receipts")]
     BlockReceipts = 2,
+    #[strum(message = "Block headers by number")]
+    BlockHeadersByNumber = 3,
 }
 
 #[derive(Clone, Debug, PartialEq, DeriveEntityModel, Eq)]

--- a/glados-web/assets/js/audit_block_status.js
+++ b/glados-web/assets/js/audit_block_status.js
@@ -213,7 +213,7 @@ async function loadChart() {
     .attr("text-anchor", "middle")
     .attr("x", width / 2)
     .attr("y", marginTop / 2)
-    .text("Status of latest audit per block (pre-merge)");
+    .text("Status of latest 4444 audit per block");
 
   const tooltip = d3
     .select("body")


### PR DESCRIPTION
Now that audits of headers by block number are added, add it as an option to the Latest Block status graph.

Also changes some strings for plural/singular consistency throughout the main page.