### PR TITLE
chore(audit): deprecate RPC for 4444 history

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2553,7 +2553,6 @@ dependencies = [
  "tokio",
  "tracing",
  "url",
- "web3",
 ]
 
 [[package]]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -26,7 +26,7 @@ services:
     restart: always
 
   glados_audit:
-    command: "--database-url postgres://postgres:${GLADOS_POSTGRES_PASSWORD}@glados_postgres:5432/glados --portal-client http://host.docker.internal:8545 --concurrency 8 --latest-strategy-weight 6 --four-fours-strategy-weight 80 --provider-url ${GLADOS_PROVIDER_URL?Provider URL required}"
+    command: "--database-url postgres://postgres:${GLADOS_POSTGRES_PASSWORD}@glados_postgres:5432/glados --portal-client http://host.docker.internal:8545 --concurrency 8 --latest-strategy-weight 6 --four-fours-strategy-weight 80"
     image: portalnetwork/glados-audit:latest
     environment:
       RUST_LOG: warn,glados_audit=info

--- a/glados-audit/Cargo.toml
+++ b/glados-audit/Cargo.toml
@@ -18,7 +18,6 @@ env_logger.workspace= true
 pgtemp.workspace = true
 enr.workspace = true
 eth_trie = "0.5.0"
-web3.workspace= true
 ethportal-api.workspace = true
 glados-core.workspace = true
 migration.workspace = true

--- a/glados-audit/src/cli.rs
+++ b/glados-audit/src/cli.rs
@@ -12,13 +12,6 @@ const DEFAULT_STATS_PERIOD: &str = "300";
 pub struct Args {
     #[arg(short, long)]
     pub database_url: String,
-    #[arg(
-        short,
-        long,
-        default_value = "",
-        help = "web3 api provider url, eg https://mainnet.infura.io/v3/..."
-    )]
-    pub provider_url: String,
 
     #[arg(short, long, default_value = "4", help = "number of auditing threads")]
     pub concurrency: u8,
@@ -135,7 +128,6 @@ impl Default for Args {
     fn default() -> Self {
         Self {
             database_url: "".to_string(),
-            provider_url: "".to_string(),
             concurrency: 4,
             latest_strategy_weight: 1,
             failed_strategy_weight: 1,
@@ -250,29 +242,6 @@ mod test {
                 HistorySelectionStrategy::Latest,
                 HistorySelectionStrategy::Random,
             ]),
-            portal_client: vec![PORTAL_CLIENT_STRING.to_owned()],
-            ..Default::default()
-        };
-        assert_eq!(result, expected);
-    }
-
-    /// Tests that the provider_url is passed through properly.
-    #[test]
-    fn test_provider_url() {
-        const PORTAL_CLIENT_STRING: &str = "ipc:////path/to/ipc";
-        const PROVIDER_URL: &str = "https://example.io/key";
-        let result = Args::parse_from([
-            "test",
-            "--provider-url",
-            PROVIDER_URL,
-            "--portal-client",
-            PORTAL_CLIENT_STRING,
-            "--database-url",
-            DATABASE_URL,
-        ]);
-        let expected = Args {
-            database_url: DATABASE_URL.to_string(),
-            provider_url: PROVIDER_URL.to_string(),
             portal_client: vec![PORTAL_CLIENT_STRING.to_owned()],
             ..Default::default()
         };

--- a/glados-audit/src/lib.rs
+++ b/glados-audit/src/lib.rs
@@ -47,8 +47,6 @@ pub(crate) mod validation;
 pub struct AuditConfig {
     /// For Glados-related data.
     pub database_url: String,
-    /// For getting on-the-fly block information.
-    pub provider_url: String,
     /// Audit History
     pub history: bool,
     /// Specific history audit strategies to run.
@@ -111,14 +109,6 @@ impl AuditConfig {
             };
             weights.insert(strat.clone(), weight);
         }
-        if args.provider_url.is_empty()
-            && args.history
-            && strategies.contains(&HistorySelectionStrategy::FourFours)
-        {
-            return Err(anyhow::anyhow!(
-                "No provider URL provided, required when `four_fours` strategy is enabled."
-            ));
-        }
         let mut portal_clients: Vec<PortalClient> = vec![];
         for client_url in args.portal_client {
             let client = PortalClient::from(client_url).await?;
@@ -127,7 +117,6 @@ impl AuditConfig {
         }
         Ok(AuditConfig {
             database_url: args.database_url,
-            provider_url: args.provider_url,
             weights,
             concurrency: args.concurrency,
             portal_clients,
@@ -245,7 +234,6 @@ async fn start_audit(
             strategy.clone(),
             tx,
             conn.clone(),
-            config.clone(),
         ));
     }
     // Collation of generated tasks, taken proportional to weights.


### PR DESCRIPTION
Now that block numbers and hashes for all pre-merge blocks are saved in the DB, use that table to source block hashes for 4444 audits instead of fetching one from an RPC