### PR TITLE
chore: bump ethportal-api to 0.7.0 for Protocol Version support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2166,9 +2166,9 @@ dependencies = [
 
 [[package]]
 name = "ethportal-api"
-version = "0.6.0"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b1f4380900784631646e69c0c391d1a45836dc6c85e43a95153a29d19c5d4264"
+checksum = "717d562776eb7715b1ba9a3799490f1d075203f14c581502eb241e81802fb9c9"
 dependencies = [
  "alloy",
  "alloy-rlp",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,7 @@ clap = { version = "4.0.26", features = ["derive"] }
 enr = "0.13.0"
 entity = { path = "entity" }
 env_logger = "0.10.0"
-ethportal-api = "0.6.0"
+ethportal-api = "0.7.0"
 futures = "0.3.31"
 glados-core = { path = "glados-core" }
 glados-monitor = { path = "glados-monitor" }


### PR DESCRIPTION
ethportal-api 0.7.0 added support for Protocol Versions. This will be needed for monitoring/graphing the protocol version of nodes on the network.

@Ktl-XV ping for review