### PR TITLE
feat: new internal transfer failure chart on dash

### DIFF
--- a/glados-web/src/lib.rs
+++ b/glados-web/src/lib.rs
@@ -130,6 +130,10 @@ pub async fn run_glados_web(config: Arc<State>) -> Result<()> {
             "/census/census-node-timeseries-data/",
             get(routes::census_timeseries),
         )
+        .route(
+            "/api/weekly-transfer-failures/",
+            get(routes::weekly_transfer_failures),
+        )
         .route("/api/audit-block-status/", get(routes::audit_block_status))
         .nest_service("/static/", serve_dir.clone())
         .fallback_service(serve_dir)

--- a/glados-web/src/routes.rs
+++ b/glados-web/src/routes.rs
@@ -1562,7 +1562,7 @@ pub async fn weekly_transfer_failures(
         .all(&state.database_connection)
         .await
         .map_err(|e| {
-            error!(err=?e, "Failed to lookup census node timeseries by client protocol versions");
+            error!(err=?e, "Failed to lookup weekly transfer failures");
             StatusCode::INTERNAL_SERVER_ERROR
         })?;
     Ok(Json(transfer_failures))

--- a/glados-web/src/routes.rs
+++ b/glados-web/src/routes.rs
@@ -1521,6 +1521,53 @@ pub async fn weekly_census_protocol_versions(
     Ok(Json(census_history_compact))
 }
 
+#[derive(FromQueryResult, Debug, Clone, Serialize)]
+pub struct TransferFailures {
+    start: DateTime<Utc>,
+    client: String,
+    failures: i64,
+}
+
+pub async fn weekly_transfer_failures(
+    http_args: HttpQuery<HashMap<String, String>>,
+    Extension(state): Extension<Arc<State>>,
+) -> Result<Json<Vec<TransferFailures>>, StatusCode> {
+    let weeks_ago: i32 = match http_args.get("weeks-ago") {
+        None => 0,
+        Some(weeks_ago) => weeks_ago.parse::<i32>().unwrap_or(0),
+    };
+
+    let transfer_failures: Vec<TransferFailures> =
+        TransferFailures::find_by_statement(Statement::from_sql_and_values(
+            DbBackend::Postgres,
+            "
+            SELECT
+                DATE_BIN('15 minutes', ca.created_at, TIMESTAMP '2001-01-01') AS start,
+                convert_from(COALESCE(substr(substr(kv.value, 1, 2), length(substr(kv.value, 1, 2)), 1), 'unknown'), 'utf8') AS client,
+                count(*) AS failures
+            FROM audit_internal_failure AS aif
+            LEFT JOIN record AS r ON aif.sender_record_id=r.id
+            LEFT JOIN key_value AS kv ON (r.id=kv.record_id AND kv.key = '\x63') -- hex('c')
+            LEFT JOIN content_audit AS ca ON aif.audit=ca.id
+            WHERE
+                ca.strategy_used = 5 AND -- Only consider 4444s audits now, there are too many History validation failures during current protocol transition
+                ca.created_at IS NOT NULL AND
+                ca.created_at > NOW() - INTERVAL '1 week' * ($1 + 1) AND
+                ca.created_at < NOW() - INTERVAL '1 week' * $1
+            GROUP BY start, client
+            ORDER BY start;
+        ",
+            vec![weeks_ago.into()],
+        ))
+        .all(&state.database_connection)
+        .await
+        .map_err(|e| {
+            error!(err=?e, "Failed to lookup census node timeseries by client protocol versions");
+            StatusCode::INTERNAL_SERVER_ERROR
+        })?;
+    Ok(Json(transfer_failures))
+}
+
 fn nest_protocol_versions_clients(
     census: Vec<CensusProtocolVersionsClientsData>,
 ) -> HashMap<String, HashMap<String, i64>> {

--- a/glados-web/templates/index.html
+++ b/glados-web/templates/index.html
@@ -187,6 +187,23 @@
             </div>
         </div>
     </div>
+    <div class="row">
+        <div class="col-lg-12 col-md-12 col-sm-12 margin-bottom">
+            <div class="card pie-box h-100">
+                <div class="card-body">
+                    <button class="question-mark" aria-label="Toggle explanation"></button>
+                    <div class="explanation">
+                        This graph shows the maximum version of the Portal Protocol supported by the nodes that were reachable at each census (every 15 minutes).
+                    </div>
+                    <div class="table-responsive">
+                        <div id="transfer-failures-graph-container">
+                            <div id="transfer-failures-graph"></div>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
   {% if subprotocol == SubProtocol::History %}
     <div class="row">
         <div class="col-lg-12 col-md-12 col-sm-12 margin-bottom">
@@ -269,6 +286,48 @@
         x: [Date.now() - 7 * 24 * 60 * 60 * 1000, Date.now()],
         y: [0, 100],
       }
+    });
+
+    areaGraph({
+        baseName: "transfer-failures",
+        baseUrl: "/api/weekly-transfer-failures/?",
+        graphTitle: "Transfer Failures this week, by client",
+        labelY: "# of failures",
+        kind: "weekly",
+        dataShape: "long",
+        keyAttribute: "client",
+        valueAttribute: "failures",
+        seriesMetadata: [
+          {
+            slug: "f",
+            color: "#3498DB",
+            name: "Fluffy",
+          },
+          {
+            slug: "t",
+            color: "#9B59B6",
+            name: "Trin",
+          },
+          {
+            slug: "s",
+            color: "#DA251D",
+            name: "Shisui",
+          },
+          {
+            slug: "u",
+            color: "#E67E22",
+            name: "Ultralight",
+          },
+          {
+            slug: "unknown",
+            color: "#BBBBBB",
+            name: "Unknown",
+          },
+        ],
+        initialRanges: {
+            x: [Date.now() - 7 * 24 * 60 * 60 * 1000, Date.now()],
+            y: [0, 20],
+        }
     });
 
   {% if subprotocol == SubProtocol::History %}

--- a/glados-web/templates/index.html
+++ b/glados-web/templates/index.html
@@ -193,7 +193,7 @@
                 <div class="card-body">
                     <button class="question-mark" aria-label="Toggle explanation"></button>
                     <div class="explanation">
-                        This graph shows the maximum version of the Portal Protocol supported by the nodes that were reachable at each census (every 15 minutes).
+                        This graph shows every transfer failure during a content audit, grouped into 15-minute buckets, by client. This includes failures that did not result in a full audit failure, because the client found another peer that had a transfer success. It uses the ENR client field which is deprecated.
                     </div>
                     <div class="table-responsive">
                         <div id="transfer-failures-graph-container">


### PR DESCRIPTION
Fix #336 

TODO:
- [x] test locally by generating some fake test data and confirming it show up in the chart

Gut check test with a couple different failure records locally:
![image](https://github.com/user-attachments/assets/30c9ee5a-4c84-4211-b84d-19e0ee7fd26f)

This screenshot ^ is the combination of this PR, #403 and #404