### PR TITLE
fix: check out code on master CI correctly

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -85,7 +85,14 @@ jobs:
                   curl -L https://api.github.com/meta | jq -r '.ssh_keys | .[]' | sed -e 's/^/github.com /' >> ~/.ssh/known_hosts
                   # check out the code, but skip lfs files, to avoid going over our lfs quota
                   GIT_LFS_SKIP_SMUDGE=1 git clone $CIRCLE_REPOSITORY_URL .
-                  git fetch origin $CIRCLE_BRANCH/head:pr-head
+                  # if this is a PR, fix the remote branch name by appending a /head
+                  # otherwise, check out the unmodified branch name
+                  if [[ $CIRCLE_BRANCH == refs/pull/* ]]; then
+                    export REMOTE_BRANCH=${CIRCLE_BRANCH}/head;
+                  else
+                    export REMOTE_BRANCH=$CIRCLE_BRANCH;
+                  fi
+                  git fetch origin $REMOTE_BRANCH:pr-head
                   git switch pr-head
             - run:
                 name: Prepare for apt upgrades

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -90,7 +90,7 @@ jobs:
                   if [[ $CIRCLE_BRANCH == refs/pull/* ]]; then
                     export REMOTE_BRANCH="${CIRCLE_BRANCH}/head";
                   else
-                    export REMOTE_BRANCH=$CIRCLE_BRANCH;
+                    export REMOTE_BRANCH="$CIRCLE_BRANCH";
                   fi
                   git fetch origin $REMOTE_BRANCH:pr-head
                   git switch pr-head

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -87,7 +87,7 @@ jobs:
                   GIT_LFS_SKIP_SMUDGE=1 git clone $CIRCLE_REPOSITORY_URL .
                   # if this is a PR, fix the remote branch name by appending a /head
                   # otherwise, check out the unmodified branch name
-                  if [[ $CIRCLE_BRANCH == refs/pull/* ]]; then
+                  if [[ $CIRCLE_BRANCH == pull/* ]]; then
                     export REMOTE_BRANCH="${CIRCLE_BRANCH}/head";
                   else
                     export REMOTE_BRANCH="$CIRCLE_BRANCH";

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -88,7 +88,7 @@ jobs:
                   # if this is a PR, fix the remote branch name by appending a /head
                   # otherwise, check out the unmodified branch name
                   if [[ $CIRCLE_BRANCH == refs/pull/* ]]; then
-                    export REMOTE_BRANCH=${CIRCLE_BRANCH}/head;
+                    export REMOTE_BRANCH="${CIRCLE_BRANCH}/head";
                   else
                     export REMOTE_BRANCH=$CIRCLE_BRANCH;
                   fi

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -92,7 +92,7 @@ jobs:
                   else
                     export REMOTE_BRANCH="$CIRCLE_BRANCH";
                   fi
-                  git fetch origin $REMOTE_BRANCH:pr-head
+                  git fetch origin "$REMOTE_BRANCH":pr-head
                   git switch pr-head
             - run:
                 name: Prepare for apt upgrades


### PR DESCRIPTION
Checking out branches requires a `/head` appended to the `CIRCLE_BRANCH` variable. All other branch runs of CI, like master, should just check out the `CIRCLE_BRANCH` unmodified. This fixes the bug that causes CI on master to fail.