### PR TITLE
feat(web): show full week in areaGraph weekly charts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,6 @@ venv
 
 # ctags files
 rusty-tags.*
+
+# local shell scripts
+*.sh

--- a/glados-web/assets/js/area_graph.js
+++ b/glados-web/assets/js/area_graph.js
@@ -322,7 +322,7 @@ async function loadChart(graphConfig) {
 
     // Get datapoint under the mouse
     let newerData = data.filter((datapoint) => datapoint.date >= x0);
-    if (newerData.length == 0) {
+    if (newerData.length === 0) {
       return;
     }
     const pointedDatum = newerData[0];

--- a/glados-web/assets/js/area_graph.js
+++ b/glados-web/assets/js/area_graph.js
@@ -537,8 +537,9 @@ async function loadChart(graphConfig) {
 
     // If chart is weekly, force the domain to the full week instead of sizing to data
     if (graphConfig.kind === "weekly") {
-      const start = Date.now() - (period.weeksAgo + 1) * 7 * 24 * 60 * 60 * 1000;
-      const end = Date.now() - period.weeksAgo * 7 * 24 * 60 * 60 * 1000;
+      const currentTime = Date.now();
+      const start = currentTime - (period.weeksAgo + 1) * 7 * 24 * 60 * 60 * 1000;
+      const end = currentTime - period.weeksAgo * 7 * 24 * 60 * 60 * 1000;
 
       x.domain([start, end]);
     }


### PR DESCRIPTION
The failure chart in #396 often has long gaps between data, so a weekly chart was oddly zoomed in.

This update to `areaGraph()` forces a weekly chart to scale to the full week, ignoring which data is available.