### PR TITLE
Name change of fluffy client to nimbus-portal

### DIFF
--- a/DOCKER_GUIDE.md
+++ b/DOCKER_GUIDE.md
@@ -16,7 +16,7 @@ where Postgres should store its data on the host machine.
 - `GLADOS_PROVIDER_URL` to the execution API provider URL.
 
 - `GLADOS_PORTAL_CLIENT` to the Portal client to be used for Portal network
-access. Currently supported values are `trin` and `fluffy`.
+access. Currently supported values are `trin` and `nimbus-portal`.
 
 Then, from the root of this repo, run:
 

--- a/docker-compose-clients.yml
+++ b/docker-compose-clients.yml
@@ -4,6 +4,6 @@ services:
     environment:
       RUST_LOG: info
     command: "--web3-transport http --web3-http-address http://0.0.0.0:8545/ --mb 0 --portal-subnetworks history,state,beacon --no-upnp --disable-poke ${GLADOS_CLIENT_ARGUMENTS:-}"
-  fluffy:
-    image: statusim/nimbus-fluffy:amd64-master-latest
+  nimbus-portal:
+    image: statusim/nimbus-portal-client:amd64-master-latest
     command: "--rpc --rpc-address=0.0.0.0 --rpc-api:eth,portal,discovery --storage-capacity=0 --disable-poke ${GLADOS_CLIENT_ARGUMENTS:-}"

--- a/entity/src/census_node.rs
+++ b/entity/src/census_node.rs
@@ -101,8 +101,8 @@ pub async fn create(
 pub enum Client {
     #[strum(props(color = "#9B59B6", name = "Trin", placeholder = "false"))]
     Trin,
-    #[strum(props(color = "#3498DB", name = "Fluffy", placeholder = "false"))]
-    Fluffy,
+    #[strum(props(color = "#3498DB", name = "Nimbus", placeholder = "false"))]
+    Nimbus,
     #[strum(props(color = "#DA251D", name = "Shisui", placeholder = "false"))]
     Shisui,
     #[strum(props(color = "#E67E22", name = "Ultralight", placeholder = "false"))]
@@ -116,7 +116,7 @@ pub enum Client {
 impl From<String> for Client {
     fn from(value: String) -> Self {
         match value.to_lowercase().as_str() {
-            "fluffy" => Client::Fluffy,
+            "nimbus" => Client::Nimbus,
             "shisui" => Client::Shisui,
             "trin" => Client::Trin,
             "ultralight" => Client::Ultralight,

--- a/glados-core/src/jsonrpc.rs
+++ b/glados-core/src/jsonrpc.rs
@@ -151,7 +151,7 @@ impl PortalClient {
 
     pub fn supports_trace(&self) -> bool {
         self.client_info.contains("trin")
-            || self.client_info.contains("fluffy")
+            || self.client_info.contains("nimbus")
             || self.client_info.contains("ultralight")
     }
 }

--- a/glados-web/assets/js/censustimeseries.js
+++ b/glados-web/assets/js/censustimeseries.js
@@ -299,8 +299,8 @@ function zipNodesAndCensusData(nodeIdsWithNickNames, censuses, records) {
             let decodedEnr = decodeEnrCached(enrString);
             let fullClientString = decodedEnr.client;
             if (fullClientString !== null) {
-                if (fullClientString[0] === 'f') {
-                    clientName = "fluffy ";
+                if (fullClientString[0] === 'f' || fullClientString[0] === 'n') {
+                    clientName = "nimbus ";
                 } else if (fullClientString[0] === 't') {
                     clientName = "trin ";
                     clientName += fullClientString.substring(2);

--- a/glados-web/assets/js/piechart.js
+++ b/glados-web/assets/js/piechart.js
@@ -97,7 +97,9 @@ function pie_chart_count(client_diversity_data) {
         if (i.client_name === "t" || i.client_name === "\\x74") {
             char_array.push({ name: "Trin", value: i.client_count, color: purple });
         } else if (i.client_name === "f" || i.client_name === "\\x66") {
-            char_array.push({ name: "Fluffy", value: i.client_count, color: blue });
+            char_array.push({ name: "Nimbus", value: i.client_count, color: blue });
+        } else if (i.client_name === "n" || i.client_name === "\\x6E") {
+            char_array.push({ name: "Nimbus", value: i.client_count, color: blue });
         } else if (i.client_name === "u" || i.client_name === "\\x75") {
             char_array.push({ name: "Ultralight", value: i.client_count, color: orange });
         } else if (i.client_name === "s" || i.client_name === "\\x73"){

--- a/glados-web/assets/js/radiusdensity.js
+++ b/glados-web/assets/js/radiusdensity.js
@@ -262,7 +262,7 @@ function radius_node_id_scatter_chart(data) {
             let red = '#DA251D'
             let grey = '#808080'
             const clientString = getClientStringFromDecodedEnr(d.raw_enr);
-                if (clientString[0] === "f") {
+                if (clientString[0] === "f" || clientString[0] === "n") {
                     return blue;
                 } else if (clientString[0] === "t") {
                     return purple; 
@@ -285,8 +285,8 @@ function getClientStringFromDecodedEnr(enr) {
 
         if (key === "c") {
             let fullClientString = String.fromCharCode.apply(null, value);
-            if (fullClientString[0] === 'f') {
-                return "fluffy";
+            if (fullClientString[0] === 'f' || fullClientString[0] === 'n') {
+                return "nimbus";
             }
             else if (fullClientString[0] === 'u') {
                 return "ultralight";

--- a/glados-web/assets/js/trace/enr.js
+++ b/glados-web/assets/js/trace/enr.js
@@ -112,8 +112,11 @@
                                         return 'ultralight';
                                     // ASCII 'f'
                                     case 0x66:
-                                        return 'fluffy';
-                                        // ASCII 's'
+                                        return 'nimbus';
+                                    // ASCII 'n'
+                                    case 0x6E:
+                                        return 'nimbus';
+                                    // ASCII 's'
                                     case 0x73:
                                         return 'shisui';
                                     default:

--- a/glados-web/assets/js/trace/main.js
+++ b/glados-web/assets/js/trace/main.js
@@ -292,6 +292,6 @@ function bigLog2(num) {
 }
 
 function supportsTrace(client) {
-  client === 'trin' | client === 'fluffy'
+  client === 'trin' | client === 'nimbus'
 }
 

--- a/glados-web/templates/index.html
+++ b/glados-web/templates/index.html
@@ -96,7 +96,7 @@
                         The Y-axis shows the radius as a percentage of the content keyspace.
                         The X-axis shows the node ID of each node found during
                         the most recent census of the network, which runs every 15 minutes.
-                        The individual clients are color coded: blue for Fluffy, purple for Trin, red for Shisui,
+                        The individual clients are color coded: blue for Nimbus, purple for Trin, red for Shisui,
                         and orange for Ultralight.
                     </div>
                     <div class="table-responsive">
@@ -301,7 +301,7 @@
           {
             slug: "f",
             color: "#3498DB",
-            name: "Fluffy",
+            name: "Nimbus",
           },
           {
             slug: "t",


### PR DESCRIPTION
The fluffy client has been renamed to Nimbus Portal client. This commit adapts glados to that name change.

The docker image is also updated with a new tag.

Replaced every usage of fluffy in the code with nimbus. There appear to be several instances where the ENR is checked for the "f" value in the client field. I kept that in place but also added the "n" value. Currently 'f' is still written by Nimbus Portal clients, but once this change gets deployed, we change change it to write 'n' in the ENR. After that the check for 'f' can be removed in glados.