### PR TITLE
fix: strum props name used Shisui instead of Samba

### DIFF
--- a/entity/src/census_node.rs
+++ b/entity/src/census_node.rs
@@ -103,7 +103,7 @@ pub enum Client {
     Trin,
     #[strum(props(color = "#3498DB", name = "Nimbus", placeholder = "false"))]
     Nimbus,
-    #[strum(props(color = "#2E8C47", name = "Shisui", placeholder = "false"))]
+    #[strum(props(color = "#2E8C47", name = "Samba", placeholder = "false"))]
     Samba,
     #[strum(props(color = "#DA251D", name = "Shisui", placeholder = "false"))]
     Shisui,


### PR DESCRIPTION
@carver pointed out I accidentally used the word "shisui" instead of samba in one place here is a PR to fix that. https://github.com/ethereum/glados/pull/426