### PR TITLE
feat(web): add page with recent transfer failures

### DIFF
--- a/entity/src/audit_internal_failure.rs
+++ b/entity/src/audit_internal_failure.rs
@@ -61,6 +61,19 @@ pub enum TransferFailureType {
     UtpTransferFailed = 2,
 }
 
+impl TryFrom<i32> for TransferFailureType {
+    type Error = String;
+    fn try_from(fail_id: i32) -> Result<Self, String> {
+        let fail_type = match fail_id {
+            0 => TransferFailureType::InvalidContent,
+            1 => TransferFailureType::UtpConnectionFailed,
+            2 => TransferFailureType::UtpTransferFailed,
+            _ => return Err(format!("Unrecognized failure type id: {fail_id}")),
+        };
+        Ok(fail_type)
+    }
+}
+
 impl From<QueryFailureKind> for TransferFailureType {
     fn from(kind: QueryFailureKind) -> Self {
         match kind {

--- a/entity/src/census_node.rs
+++ b/entity/src/census_node.rs
@@ -128,6 +128,19 @@ impl From<String> for Client {
     }
 }
 
+pub fn client_from_short_name(short: String) -> Client {
+    match short.to_lowercase().as_str() {
+        // The old name for Nimbus was "Fluffy" so we include "f" here
+        "n" | "f" => Client::Nimbus,
+        "a" => Client::Samba,
+        "s" => Client::Shisui,
+        "t" => Client::Trin,
+        "u" => Client::Ultralight,
+        "unknown" => Client::Unknown,
+        _ => Client::Other,
+    }
+}
+
 impl From<Option<String>> for Client {
     fn from(value: Option<String>) -> Self {
         match value {

--- a/glados-web/src/lib.rs
+++ b/glados-web/src/lib.rs
@@ -66,6 +66,7 @@ pub async fn run_glados_web(config: Arc<State>) -> Result<()> {
         .route("/census/", get(routes::single_census_view))
         .route("/census/explorer", get(routes::census_explorer))
         .route("/clients", get(routes::clients_overview))
+        .route("/diagnostics", get(routes::diagnostics))
         .route("/network/node/:node_id_hex/", get(routes::node_detail))
         .route(
             "/network/node/:node_id_hex/enr/:enr_seq/",

--- a/glados-web/src/routes.rs
+++ b/glados-web/src/routes.rs
@@ -35,8 +35,9 @@ use tracing::{debug, error, info, warn};
 use crate::templates::{
     AuditDashboardTemplate, AuditTableTemplate, CensusExplorerTemplate, ClientsTemplate,
     ContentAuditDetailTemplate, ContentIdDetailTemplate, ContentIdListTemplate,
-    ContentKeyDetailTemplate, ContentKeyListTemplate, EnrDetailTemplate, HtmlTemplate,
-    IndexTemplate, NodeDetailTemplate, PaginatedCensusListTemplate, SingleCensusViewTemplate,
+    ContentKeyDetailTemplate, ContentKeyListTemplate, DiagnosticsTemplate, EnrDetailTemplate,
+    HtmlTemplate, IndexTemplate, NodeDetailTemplate, PaginatedCensusListTemplate,
+    SingleCensusViewTemplate,
 };
 use crate::{state::State, templates::AuditTuple};
 use entity::{
@@ -1522,7 +1523,7 @@ pub async fn weekly_census_protocol_versions(
 }
 
 #[derive(FromQueryResult, Debug, Clone, Serialize)]
-pub struct TransferFailures {
+pub struct TransferFailureBatches {
     start: DateTime<Utc>,
     client: String,
     failures: i64,
@@ -1531,14 +1532,14 @@ pub struct TransferFailures {
 pub async fn weekly_transfer_failures(
     http_args: HttpQuery<HashMap<String, String>>,
     Extension(state): Extension<Arc<State>>,
-) -> Result<Json<Vec<TransferFailures>>, StatusCode> {
+) -> Result<Json<Vec<TransferFailureBatches>>, StatusCode> {
     let weeks_ago: i32 = match http_args.get("weeks-ago") {
         None => 0,
         Some(weeks_ago) => weeks_ago.parse::<i32>().unwrap_or(0),
     };
 
-    let transfer_failures: Vec<TransferFailures> =
-        TransferFailures::find_by_statement(Statement::from_sql_and_values(
+    let transfer_failures: Vec<TransferFailureBatches> =
+        TransferFailureBatches::find_by_statement(Statement::from_sql_and_values(
             DbBackend::Postgres,
             "
             SELECT
@@ -2056,6 +2057,51 @@ async fn generate_client_diversity_data(
             ", vec![census_id.into()])
         ).all(&state.database_connection).await.unwrap(),
     )
+}
+
+#[derive(FromQueryResult, Debug, Clone, Serialize)]
+pub struct TransferFailures {
+    pub audit: i32,
+    pub client: String,
+    pub created_at: DateTime<Utc>,
+    pub failure_type: i32,
+}
+
+pub async fn diagnostics(
+    Extension(state): Extension<Arc<State>>,
+) -> Result<HtmlTemplate<DiagnosticsTemplate>, StatusCode> {
+    // Query to get the 20 most recent internal failures joined with audits for timestamps
+    // TODO: include more than 4444 errors (or maybe a dropdown to select which kind of error)
+    let transfer_failures: Vec<TransferFailures> =
+        TransferFailures::find_by_statement(Statement::from_sql_and_values(
+            DbBackend::Postgres,
+            "
+            SELECT
+                aif.audit,
+                convert_from(COALESCE(substr(substr(kv.value, 1, 2), length(substr(kv.value, 1, 2)), 1), 'unknown'), 'utf8') AS client,
+                ca.created_at,
+                aif.failure_type
+            FROM audit_internal_failure AS aif
+            LEFT JOIN record AS r ON aif.sender_record_id=r.id
+            LEFT JOIN key_value AS kv ON (r.id=kv.record_id AND kv.key = '\x63') -- hex('c')
+            LEFT JOIN content_audit AS ca ON aif.audit=ca.id
+            WHERE ca.strategy_used = 5 AND ca.created_at IS NOT NULL
+            ORDER BY created_at DESC
+            LIMIT 20;",
+            vec![],
+        ))
+        .all(&state.database_connection)
+        .await
+        .map_err(|e| {
+            error!(err=?e, "Failed to lookup weekly transfer failures");
+            StatusCode::INTERNAL_SERVER_ERROR
+        })?;
+
+    let template = DiagnosticsTemplate {
+        failures: transfer_failures,
+    };
+
+    Ok(HtmlTemplate(template))
 }
 
 #[cfg(test)]

--- a/glados-web/src/templates.rs
+++ b/glados-web/src/templates.rs
@@ -7,6 +7,7 @@ use sea_orm::strum::{EnumMessage, EnumProperty};
 
 use crate::routes::{
     CalculatedRadiusChartData, ClientDiversityResult, PaginatedCensusListResult, RawEnr,
+    TransferFailures,
 };
 use entity::{
     audit_result_latest::ContentType,
@@ -129,6 +130,13 @@ pub struct ClientsTemplate {
     pub subprotocol: SubProtocol,
     pub clients: Vec<Client>,
     pub operating_systems: Vec<OperatingSystem>,
+}
+
+#[derive(Template)]
+#[template(path = "diagnostics.html")]
+pub struct DiagnosticsTemplate {
+    // TODO: Make a struct for each failure record
+    pub failures: Vec<TransferFailures>,
 }
 
 pub struct HtmlTemplate<T: Template>(pub T);

--- a/glados-web/src/templates.rs
+++ b/glados-web/src/templates.rs
@@ -7,7 +7,7 @@ use sea_orm::strum::{EnumMessage, EnumProperty};
 
 use crate::routes::{
     CalculatedRadiusChartData, ClientDiversityResult, PaginatedCensusListResult, RawEnr,
-    TransferFailures,
+    TransferFailure,
 };
 use entity::{
     audit_result_latest::ContentType,
@@ -135,8 +135,7 @@ pub struct ClientsTemplate {
 #[derive(Template)]
 #[template(path = "diagnostics.html")]
 pub struct DiagnosticsTemplate {
-    // TODO: Make a struct for each failure record
-    pub failures: Vec<TransferFailures>,
+    pub failures: Vec<TransferFailure>,
 }
 
 pub struct HtmlTemplate<T: Template>(pub T);

--- a/glados-web/templates/base.html
+++ b/glados-web/templates/base.html
@@ -36,6 +36,9 @@
                 <li class="nav-item">
                     <a class="nav-link active" aria-current="page" style="margin-left: 20px;" href="/clients">Clients</a>
                 </li>
+                <li class="nav-item">
+                    <a class="nav-link active" aria-current="page" style="margin-left: 20px;" href="/diagnostics">Diagnostics</a>
+                </li>
             </ul>
             <select name="network-selector" id="network-selector" class="form-select" style="width: auto;">
                 <option value="History">History</option>
@@ -49,7 +52,7 @@
         // Logic for managing syncing network selector & URL parameter
         document.addEventListener('DOMContentLoaded', function() {
             const networkSelector = document.getElementById('network-selector');
-            
+
             function syncSelectorWithUrl() {
                 const urlParams = new URLSearchParams(window.location.search);
                 const networkParam = urlParams.get('network');

--- a/glados-web/templates/diagnostics.html
+++ b/glados-web/templates/diagnostics.html
@@ -1,0 +1,50 @@
+{% extends "base.html" %}
+
+{% block title %}Diagnostics{% endblock %}
+
+{% block head %}
+<script src="/static/js/explanations.js"></script>
+
+<link rel="stylesheet" href="/static/css/trace.css">
+{% endblock %}
+
+{% block content %}
+<div class="container">
+    <h1>Diagnostics</h1>
+    <div class="row">
+        <div class="col-lg-12 col-md-12 col-sm-12 margin-bottom">
+            <div class="card pie-box h-100">
+                <div class="card-body">
+                    <button class="question-mark" aria-label="Toggle explanation"></button>
+                    <div class="explanation">
+                        This table shows the 20 most recent internal transfer failures that occurred during content audits.
+                    </div>
+                    <h2>Recent Transfer Failures</h2>
+                    <div class="table-responsive">
+                        <table class="table">
+                            <thead>
+                                <tr>
+                                    <th scope="col">Client</th>
+                                    <th scope="col">Audit ID</th>
+                                    <th scope="col">Failure Type</th>
+                                    <th scope="col">Time</th>
+                                </tr>
+                            </thead>
+                            <tbody>
+                                {% for failure in failures %}
+                                <tr>
+                                    <td>{{ failure.client }}</td>
+                                    <td><a href="/audit/id/{{ failure.audit }}">{{ failure.audit }}</a></td>
+                                    <td>{{ failure.failure_type }}</td>
+                                    <td>{{ failure.created_at }}</td>
+                                </tr>
+                                {% endfor %}
+                            </tbody>
+                        </table>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+</div>
+{% endblock %}


### PR DESCRIPTION
Often, we want to dig into the details of why certain clients are producing transfer failures. A next step from seeing them show up in the graph is to dig into the specifics: which client, what type of failure, and which audit triggered the failure. This new page lists all those things, linking to the audit.

TODO:
- [x] convert from short client name to full name
- [x] convert from failure type number to human-readable
- [x] add title to list of transfer failures?
- [x] is it time to include more than just the 4444 errors? _Probably not, and even if we do, then we want something smarter to let us filter by audit strategy in a drop-down or something_

### Preview with prod data:
![image](https://github.com/user-attachments/assets/0ef11114-616a-4cd9-a522-9f747772a196)
