### PR TITLE
Remove Non-Working URL

### DIFF
--- a/glados-monitor/src/beacon.rs
+++ b/glados-monitor/src/beacon.rs
@@ -18,7 +18,7 @@ use tokio::time::sleep;
 use tracing::{debug, error, info};
 
 /// Nimbus node to retrieve beacon data from.
-pub const PANDA_OPS_BEACON: &str = "https://nimbus.mainnet.ethpandaops.io";
+pub const PANDA_OPS_BEACON: &str = "";
 /// How often the provider will be queried for a new block hash.
 const POLL_PERIOD_SECONDS: u64 = 1;
 // Beacon chain mainnet genesis time: Tue Dec 01 2020 12:00:23 GMT+0000


### PR DESCRIPTION
I removed the non-working URL for Nimbus mainnet. If you have an updated URL, please provide it, and I'll be happy to replace it.