### PR TITLE
feat: implement retention background tasks

### DIFF
--- a/glados-audit/src/cli.rs
+++ b/glados-audit/src/cli.rs
@@ -8,6 +8,9 @@ const DEFAULT_STATS_PERIOD: &str = "300";
 /// The first post-merge block number.
 const MAINNET_MERGE_BLOCK_HEIGHT: u64 = 15537394;
 
+/// How long to keep audits.
+const DEFAULT_RETENTION_PERIOD_DAYS: &str = "30";
+
 #[derive(Parser, Debug, Eq, PartialEq)]
 #[command(author, version, about, long_about = None)]
 pub struct Args {
@@ -47,6 +50,9 @@ pub struct Args {
 
     #[arg(long, default_value = DEFAULT_STATS_PERIOD, help = "stats recording period (seconds)")]
     pub stats_recording_period: u64,
+
+    #[arg(long, default_value = DEFAULT_RETENTION_PERIOD_DAYS, help = "how long to store audits (in days)")]
+    pub retention_period_days: Option<u32>,
 
     #[arg(long, action(ArgAction::Append))]
     pub portal_client: Vec<String>,
@@ -114,6 +120,7 @@ mod test {
                 start_block: 0,
                 end_block: MAINNET_MERGE_BLOCK_HEIGHT - 1,
                 stats_recording_period: 300,
+                retention_period_days: None,
                 portal_client: vec!["ipc:////tmp/trin-jsonrpc.ipc".to_owned()],
             }
         }

--- a/glados-audit/src/config.rs
+++ b/glados-audit/src/config.rs
@@ -2,6 +2,7 @@ use std::{
     collections::HashMap, ops::RangeInclusive, thread::available_parallelism, time::Duration,
 };
 
+use chrono::TimeDelta;
 use entity::SelectionStrategy;
 use glados_core::jsonrpc::PortalClient;
 use sea_orm::{Database, DatabaseConnection};
@@ -26,6 +27,8 @@ pub struct AuditConfig {
     pub portal_clients: Vec<PortalClient>,
     /// The frequency of recording the current audit performance in audit_stats table.
     pub stats_recording_period: Duration,
+    /// How long to store audits. We periodically delete audits that are too old.
+    pub retention_period: Option<TimeDelta>,
 }
 
 impl AuditConfig {
@@ -70,6 +73,9 @@ impl AuditConfig {
             max_audit_rate: args.max_audit_rate,
             portal_clients,
             stats_recording_period: Duration::from_secs(args.stats_recording_period),
+            retention_period: args
+                .retention_period_days
+                .map(|retention_period_days| TimeDelta::days(retention_period_days as i64)),
         })
     }
 }

--- a/glados-audit/src/lib.rs
+++ b/glados-audit/src/lib.rs
@@ -14,6 +14,7 @@ use crate::{config::AuditConfig, strategy::execute_audit_strategy, task::AuditTa
 
 pub mod cli;
 pub mod config;
+pub mod retention;
 pub mod stats;
 mod strategy;
 mod task;

--- a/glados-audit/src/retention.rs
+++ b/glados-audit/src/retention.rs
@@ -1,0 +1,50 @@
+use std::time::Duration;
+
+use chrono::{TimeDelta, Utc};
+use entity::audit;
+use sea_orm::{ColumnTrait, DatabaseConnection, EntityTrait, QueryFilter};
+use tokio::time::{interval, MissedTickBehavior};
+use tracing::{error, info};
+
+use crate::config::AuditConfig;
+
+const PERIOD: Duration = Duration::from_secs(10); // 10 seconds
+
+/// Loops indefinitely, periodically (once 10 seconds) deletes old audits
+pub async fn periodically_delete_old_audits(config: AuditConfig) {
+    let Some(retention_period) = config.retention_period else {
+        return;
+    };
+    info!(
+        "initializing task for deleting audits older than {} days",
+        retention_period.num_days()
+    );
+
+    let mut interval = interval(PERIOD);
+    interval.set_missed_tick_behavior(MissedTickBehavior::Delay);
+
+    loop {
+        interval.tick().await;
+
+        delete_old_audits(retention_period, &config.database_connection).await;
+    }
+}
+
+pub async fn delete_old_audits(retention_period: TimeDelta, conn: &DatabaseConnection) {
+    match audit::Entity::delete_many()
+        .filter(audit::Column::CreatedAt.lt(Utc::now() - retention_period))
+        .exec(conn)
+        .await
+    {
+        Ok(delete_result) => {
+            info!(
+                "Deleted {} audits older than {} days",
+                delete_result.rows_affected,
+                retention_period.num_days(),
+            );
+        }
+        Err(err) => {
+            error!(%err, "Failed to delete too old audits");
+        }
+    }
+}

--- a/glados-cartographer/src/cli.rs
+++ b/glados-cartographer/src/cli.rs
@@ -3,29 +3,34 @@ use entity::Subprotocol;
 use std::path::PathBuf;
 use url::Url;
 
-// 15 minutes
+/// 15 minutes
 const DEFAULT_CENSUS_INTERVAL: &str = "900";
 
-// Number of concurrent requests that can be in progress towards the connected portal client.
+/// Number of concurrent requests that can be in progress towards the connected portal client.
 const DEFAULT_CONCURRENCY: &str = "4";
+
+/// How long to keep census data.
+const DEFAULT_RETENTION_PERIOD_DAYS: &str = "30";
 
 #[derive(Clone, Debug, Eq, Parser, PartialEq)]
 #[command(author, version, about, long_about = None)]
 pub struct Args {
+    #[arg(long)]
+    pub subprotocol: Subprotocol,
     #[arg(short, long)]
     pub database_url: String,
-    #[arg(short = 'p', long, requires = "transport")]
+    #[arg(long, requires = "transport")]
     pub ipc_path: Option<PathBuf>,
-    #[arg(short = 'u', long, requires = "transport")]
+    #[arg(long, requires = "transport")]
     pub http_url: Option<Url>,
-    #[arg(short, long)]
+    #[arg(long)]
     pub transport: TransportType,
-    #[arg(short = 'i', long, default_value = DEFAULT_CENSUS_INTERVAL)]
-    pub census_interval: u64,
-    #[arg(short, long, default_value = DEFAULT_CONCURRENCY)]
+    #[arg(long, default_value = DEFAULT_CONCURRENCY)]
     pub concurrency: usize,
-    #[arg(short, long)]
-    pub subprotocol: Subprotocol,
+    #[arg(long, default_value = DEFAULT_CENSUS_INTERVAL)]
+    pub census_interval: u64,
+    #[arg(long, default_value = DEFAULT_RETENTION_PERIOD_DAYS)]
+    pub retention_period_days: Option<u32>,
 }
 
 /// Used by a user to specify the intended form of transport

--- a/glados-cartographer/src/retention.rs
+++ b/glados-cartographer/src/retention.rs
@@ -1,0 +1,47 @@
+use std::time::Duration;
+
+use chrono::{TimeDelta, Utc};
+use entity::census;
+use sea_orm::{ColumnTrait, DatabaseConnection, EntityTrait, QueryFilter};
+use tokio::time::{interval, MissedTickBehavior};
+use tracing::{error, info};
+
+const PERIOD: Duration = Duration::from_secs(60 * 60); // 1 hour
+
+/// Loops indefinitely, periodically (once per hour) deletes old census data
+pub async fn periodically_delete_old_census(
+    retention_period: Option<TimeDelta>,
+    conn: DatabaseConnection,
+) {
+    let Some(retention_period) = retention_period else {
+        return;
+    };
+    info!(
+        "Initializing task for deleting censuses older than {} days",
+        retention_period.num_days(),
+    );
+
+    let mut interval = interval(PERIOD);
+    interval.set_missed_tick_behavior(MissedTickBehavior::Delay);
+
+    loop {
+        interval.tick().await;
+
+        match census::Entity::delete_many()
+            .filter(census::Column::StartedAt.lt(Utc::now() - retention_period))
+            .exec(&conn)
+            .await
+        {
+            Ok(delete_result) => {
+                info!(
+                    "Deleted {} censuses older than {} days",
+                    delete_result.rows_affected,
+                    retention_period.num_days(),
+                );
+            }
+            Err(err) => {
+                error!(%err, "Failed to delete censuses");
+            }
+        }
+    }
+}


### PR DESCRIPTION
Add tasks to audit and cartographer that delete too old data.

By default, we delete audits and censuses older than 30 days.

Audits are deleted once every 10 seconds, while Censuses are deleted once per hour.