### PR TITLE
feat: show content type instead of protocol in audit table

### DIFF
--- a/entity/src/audit.rs
+++ b/entity/src/audit.rs
@@ -208,6 +208,7 @@ pub async fn get_failed_keys(
 
 #[cfg(test)]
 mod tests {
+    use alloy_primitives::B256;
     use enr::NodeId;
     use ethportal_api::HistoryContentKey;
 
@@ -220,7 +221,8 @@ mod tests {
         let (conn, _db) = setup_database().await?;
 
         let block_number = 12_345_678;
-        let key = HistoryContentKey::new_block_header_by_number(block_number);
+        let block_hash = B256::random();
+        let key = HistoryContentKey::new_block_body(block_hash);
 
         let content_model =
             content::get_or_create(Subprotocol::History, &key, Some(block_number), &conn).await?;
@@ -267,8 +269,9 @@ mod tests {
         let (conn, _db) = setup_database().await?;
 
         let block_number = 12_345_678;
-        let key = HistoryContentKey::new_block_header_by_number(block_number);
+        let block_hash = B256::random();
 
+        let key = HistoryContentKey::new_block_body(block_hash);
         let content =
             content::get_or_create(Subprotocol::History, &key, Some(block_number), &conn).await?;
         let client = client::get_or_create("trin v0.1.0".to_string(), &conn).await?;

--- a/entity/src/content.rs
+++ b/entity/src/content.rs
@@ -136,10 +136,9 @@ mod tests {
     /// Returns a history content key representing the header with proof
     /// for block hash `0x0001...1e1f`
     fn history_content() -> (HistoryContentKey, u64) {
-        let block_number = 12_345_678;
         (
-            HistoryContentKey::new_block_header_by_number(block_number),
-            block_number,
+            HistoryContentKey::new_block_body(B256::random()),
+            12_345_678,
         )
     }
 

--- a/entity/src/enums/content_type.rs
+++ b/entity/src/enums/content_type.rs
@@ -1,28 +1,17 @@
 use ethportal_api::HistoryContentKey;
 use sea_orm::prelude::*;
 use serde::Deserialize;
-use strum::{EnumMessage, EnumString};
+use strum::Display;
 
 // Not using the constants in ethportal-api because seaorm does not support DeriveActiveEnum from a
 // variable
-#[derive(
-    Debug,
-    Clone,
-    Copy,
-    Eq,
-    PartialEq,
-    EnumIter,
-    DeriveActiveEnum,
-    Deserialize,
-    EnumMessage,
-    EnumString,
-)]
+#[derive(Debug, Clone, Copy, Eq, PartialEq, EnumIter, DeriveActiveEnum, Deserialize, Display)]
 #[sea_orm(rs_type = "i32", db_type = "Integer")]
 #[strum(serialize_all = "snake_case")]
 pub enum ContentType {
-    #[strum(message = "Block bodies")]
+    #[strum(to_string = "Bodies")]
     BlockBodies = 0,
-    #[strum(message = "Block receipts")]
+    #[strum(to_string = "Receipts")]
     BlockReceipts = 1,
 }
 
@@ -31,7 +20,7 @@ impl AsRef<ContentType> for HistoryContentKey {
         match self {
             HistoryContentKey::BlockBody(_) => &ContentType::BlockBodies,
             HistoryContentKey::BlockReceipts(_) => &ContentType::BlockReceipts,
-            _ => &ContentType::BlockBodies,
+            _ => unimplemented!("Content type not supported: {self}"),
         }
     }
 }

--- a/glados-web/templates/audit_table.html
+++ b/glados-web/templates/audit_table.html
@@ -40,7 +40,7 @@
                                 <tr>
                                     <th scope="col">Audit</th>
                                     <th scope="col">Result</th>
-                                    <th scope="col">Sub-protocol</th>
+                                    <th scope="col">Content Type</th>
                                     <th scope="col">Strategy</th>
                                     <th scope="col">Content Key</th>
                                     <th scope="col">Block number</th>
@@ -60,7 +60,7 @@
                                     <td><span
                                             class="badge text-bg-{% if audit.is_success() %}success{% else %}danger{% endif %}">{%
                                             if audit.is_success() %}Success{% else %}Fail{% endif %}</span></td>
-                                    <td>{{ content.subprotocol.as_text() }}</td>
+                                    <td>{{ content.content_type }}</td>
                                     <td>{{ audit.strategy.as_str() }}</td>
                                     <td>
                                         <a href="/content/key/{{content.key_as_hex()}}/">


### PR DESCRIPTION
Showing content type instead of protocol is much more useful for audit table