### PR TITLE
feat: remove version from docker compose file

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,3 @@
-version: '3'
 services:
 
   glados_postgres:


### PR DESCRIPTION
The `version` attribute is obsolete, so I removed it.