### PR TITLE
Docker: define the nimbus_portal_client RPC port to 8545

### DIFF
--- a/docker-compose-clients.yml
+++ b/docker-compose-clients.yml
@@ -6,4 +6,4 @@ services:
     command: "--web3-transport http --web3-http-address http://0.0.0.0:8545/ --mb 0 --portal-subnetworks history,beacon --no-upnp --disable-poke ${GLADOS_CLIENT_ARGUMENTS:-}"
   nimbus-portal:
     image: statusim/nimbus-portal-client:amd64-master-latest
-    command: "--rpc --rpc-address=0.0.0.0 --rpc-api:portal,discovery --storage-capacity=0 --disable-poke ${GLADOS_CLIENT_ARGUMENTS:-}"
+    command: "--rpc --rpc-address=0.0.0.0 --rpc-port:8545 --rpc-api:portal,discovery --storage-capacity=0 --disable-poke ${GLADOS_CLIENT_ARGUMENTS:-}"


### PR DESCRIPTION
Default RPC port was changed to 8565, not to conflict with EL RPC interfaces.

Assuming here that glados specifically uses 8545, we need to set it to that at cli options.

This was recently changed for our client, see also https://github.com/status-im/nimbus-eth1/pull/3700